### PR TITLE
feat: improve skill review scores and add Tessl review workflow

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/loom-accessibility/SKILL.md
+++ b/skills/loom-accessibility/SKILL.md
@@ -1,28 +1,28 @@
 ---
 name: loom-accessibility
-description: Web accessibility patterns, WCAG compliance, and inclusive design. Use when implementing accessible UI, keyboard navigation, screen reader support, focus management, semantic HTML, or auditing for compliance. Triggers: accessibility, a11y, WCAG, ARIA, screen reader, keyboard navigation, focus, tab order, tabindex, alt text, color contrast, semantic HTML, landmark, role, aria-label, aria-labelledby, aria-describedby, aria-live, aria-expanded, aria-selected, aria-hidden, focus trap, roving tabindex, skip link, assistive technology.
+description: "Use when implementing accessible UI components, auditing WCAG compliance, adding keyboard navigation, screen reader support, focus management, semantic HTML, ARIA patterns, or color contrast checks."
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+trigger-keywords: accessibility, a11y, WCAG, ARIA, screen reader, keyboard navigation, focus, tab order, tabindex, alt text, color contrast, semantic HTML, landmark, role, aria-label, aria-labelledby, aria-describedby, aria-live, aria-expanded, aria-selected, aria-hidden, focus trap, roving tabindex, skip link, assistive technology
 ---
 
 # Accessibility
 
 ## Overview
 
-Web accessibility ensures that websites and applications are usable by everyone, including people with disabilities. This skill covers WCAG 2.1 compliance, semantic HTML, ARIA patterns, keyboard navigation, screen reader testing, visual accessibility, focus management, and automated testing.
-
-This skill combines engineering implementation with design considerations - use when building accessible UIs, auditing compliance, or designing inclusive user experiences.
+Web accessibility ensures websites and applications are usable by everyone, including people with disabilities. This skill covers WCAG 2.1 compliance, semantic HTML, ARIA patterns, keyboard navigation, screen reader support, visual accessibility, focus management, and automated testing.
 
 ## Instructions
 
-### 1. WCAG 2.1 Compliance Checklist
+### 1. WCAG 2.1 Compliance
 
 WCAG is organized around four principles (POUR):
 
-| Principle          | Description                                       | Key Guidelines                                 |
-| ------------------ | ------------------------------------------------- | ---------------------------------------------- |
-| **Perceivable**    | Information must be presentable to users          | Text alternatives, captions, adaptable content |
-| **Operable**       | Interface must be operable                        | Keyboard accessible, enough time, no seizures  |
-| **Understandable** | Information and operation must be understandable  | Readable, predictable, input assistance        |
-| **Robust**         | Content must be robust for assistive technologies | Compatible with current and future tools       |
+| Principle | Description | Key Guidelines |
+|-----------|-------------|----------------|
+| **Perceivable** | Information must be presentable to users | Text alternatives, captions, adaptable content |
+| **Operable** | Interface must be operable | Keyboard accessible, enough time, no seizures |
+| **Understandable** | Information and operation must be understandable | Readable, predictable, input assistance |
+| **Robust** | Content must work with assistive technologies | Compatible with current and future tools |
 
 #### Conformance Levels
 
@@ -30,351 +30,99 @@ WCAG is organized around four principles (POUR):
 - **Level AA**: Addresses major barriers (legal requirement in many jurisdictions)
 - **Level AAA**: Highest level (nice to have for specific audiences)
 
-#### Quick Compliance Checklist
-
-**Level A (Essential):**
+#### Level A Essentials
 
 - All images have alt text (1.1.1)
 - Videos have captions (1.2.2)
-- Color is not the only visual means of conveying information (1.4.1)
+- Color is not the only means of conveying information (1.4.1)
 - All functionality available from keyboard (2.1.1)
 - Users can pause, stop, or hide moving content (2.2.2)
-- Page has a title (2.4.2)
-- Focus order preserves meaning (2.4.3)
+- Page has a title (2.4.2); focus order preserves meaning (2.4.3)
 - Link purpose clear from text or context (2.4.4)
-- Pages have headings and labels (2.4.6)
 - Forms have labels or instructions (3.3.2)
-- Parsing: no duplicate IDs, proper nesting (4.1.1)
 - Name, role, value available for all UI components (4.1.2)
 
-**Level AA (Standard):**
+#### Level AA Standard
 
-- Captions for all live audio (1.2.4)
-- Audio description for video (1.2.5)
 - Contrast ratio at least 4.5:1 for normal text, 3:1 for large text (1.4.3)
-- Text can be resized to 200% without loss of functionality (1.4.4)
-- Images of text avoided (1.4.5)
-- Multiple ways to find pages (2.4.5)
-- Headings and labels describe topic or purpose (2.4.6)
-- Focus visible (2.4.7)
+- Text resizable to 200% without loss of functionality (1.4.4)
+- Multiple ways to find pages (2.4.5); focus visible (2.4.7)
 - Language of page identified (3.1.1)
-- Input errors suggested (3.3.3)
-- Error prevention for legal/financial transactions (3.3.4)
-
-**Level AAA (Enhanced):**
-
-- Sign language interpretation for videos (1.2.6)
-- Extended audio description (1.2.7)
-- Contrast ratio at least 7:1 (1.4.6)
-- No background audio or easy to turn off (1.4.7)
-- Section headings used (2.4.10)
-- Context-sensitive help available (3.3.5)
-
-```typescript
-// WCAG 2.1 checklist implementation
-interface WCAGChecklistItem {
-  id: string;
-  level: "A" | "AA" | "AAA";
-  principle: "perceivable" | "operable" | "understandable" | "robust";
-  description: string;
-  howToTest: string;
-}
-
-const wcagChecklist: WCAGChecklistItem[] = [
-  {
-    id: "1.1.1",
-    level: "A",
-    principle: "perceivable",
-    description:
-      "Non-text Content: All non-text content has a text alternative",
-    howToTest: "Check all images have meaningful alt text",
-  },
-  {
-    id: "1.4.3",
-    level: "AA",
-    principle: "perceivable",
-    description:
-      "Contrast (Minimum): Text has contrast ratio of at least 4.5:1",
-    howToTest: "Use contrast checker tool on all text elements",
-  },
-  {
-    id: "2.1.1",
-    level: "A",
-    principle: "operable",
-    description: "Keyboard: All functionality is operable via keyboard",
-    howToTest: "Tab through entire page without using mouse",
-  },
-  // ... additional items
-];
-```
+- Input errors suggested (3.3.3); error prevention for legal/financial (3.3.4)
 
 ### 2. Semantic HTML
 
-```html
-<!-- Bad: Non-semantic structure -->
-<div class="header">
-  <div class="nav">
-    <div class="nav-item">Home</div>
-    <div class="nav-item">About</div>
-  </div>
-</div>
-<div class="main-content">
-  <div class="article">
-    <div class="title">Article Title</div>
-    <div class="content">Content here...</div>
-  </div>
-</div>
-<div class="footer">Footer content</div>
+Always prefer semantic elements over generic divs with ARIA roles.
 
-<!-- Good: Semantic structure -->
+```html
+<!-- Bad: div soup -->
+<div class="header"><div class="nav"><div class="nav-item">Home</div></div></div>
+<div class="main-content"><div class="article"><div class="title">Title</div></div></div>
+
+<!-- Good: semantic structure -->
 <header>
   <nav aria-label="Main navigation">
-    <ul>
-      <li><a href="/">Home</a></li>
-      <li><a href="/about">About</a></li>
-    </ul>
+    <ul><li><a href="/">Home</a></li></ul>
   </nav>
 </header>
 <main>
-  <article>
-    <h1>Article Title</h1>
-    <p>Content here...</p>
-  </article>
+  <article><h1>Title</h1><p>Content here...</p></article>
 </main>
 <footer>Footer content</footer>
 ```
 
-#### Semantic Element Reference
+Key semantic elements:
 
-```typescript
-// Semantic HTML element mapping
-const semanticElements = {
-  // Sectioning
-  header: "Introductory content, typically contains navigation",
-  nav: "Navigation links",
-  main: "Main content of the document (only one per page)",
-  article: "Self-contained content that could be distributed independently",
-  section: "Thematic grouping of content with a heading",
-  aside: "Content tangentially related to the main content",
-  footer: "Footer for its nearest sectioning content",
-
-  // Text content
-  h1_h6: "Heading levels (maintain hierarchy, one h1 per page)",
-  p: "Paragraph",
-  ul_ol: "Unordered/ordered lists",
-  blockquote: "Extended quotation",
-  figure: "Self-contained content with optional caption",
-  figcaption: "Caption for a figure",
-
-  // Interactive
-  button: "Clickable button (not for links)",
-  a: "Hyperlink to another page or resource",
-  details: "Disclosure widget with summary",
-  dialog: "Modal or non-modal dialog box",
-
-  // Form elements
-  form: "Interactive form",
-  label: "Caption for form element (always use with inputs)",
-  fieldset: "Group of related form elements",
-  legend: "Caption for fieldset",
-};
-```
+- **Sectioning**: `header`, `nav`, `main` (one per page), `article`, `section`, `aside`, `footer`
+- **Text**: `h1`-`h6` (maintain hierarchy), `p`, `ul`/`ol`, `blockquote`, `figure`/`figcaption`
+- **Interactive**: `button` (actions), `a` (links), `details`/`summary`, `dialog`
+- **Forms**: `form`, `label` (always pair with inputs), `fieldset`/`legend`
 
 ### 3. ARIA Attributes
 
-```typescript
-// ARIA roles, states, and properties
+**First rule of ARIA**: Do not use ARIA if semantic HTML can do it. ARIA fixes what HTML cannot express.
 
-// Landmark roles
-const landmarkRoles = [
-  "banner", // Page header (use with <header>)
-  "navigation", // Navigation (use with <nav>)
-  "main", // Main content (use with <main>)
-  "complementary", // Supporting content (use with <aside>)
-  "contentinfo", // Footer (use with <footer>)
-  "search", // Search functionality
-  "form", // Form (use with <form>)
-  "region", // Generic landmark (requires aria-label)
-];
+**Landmark roles**: `banner`, `navigation`, `main`, `complementary`, `contentinfo`, `search`, `form`, `region`
 
-// Widget roles
-const widgetRoles = [
-  "button",
-  "checkbox",
-  "dialog",
-  "menu",
-  "menuitem",
-  "progressbar",
-  "slider",
-  "tab",
-  "tablist",
-  "tabpanel",
-  "tooltip",
-  "tree",
-  "treeitem",
-];
+**Common attributes**:
 
-// Common ARIA attributes
-interface AriaAttributes {
-  // Labels and descriptions
-  "aria-label": string; // Accessible name
-  "aria-labelledby": string; // ID of labelling element
-  "aria-describedby": string; // ID of describing element
+- **Labels**: `aria-label`, `aria-labelledby`, `aria-describedby`
+- **States**: `aria-expanded`, `aria-selected`, `aria-checked`, `aria-pressed`, `aria-disabled`, `aria-hidden`
+- **Live regions**: `aria-live` (`polite` or `assertive`), `aria-atomic`
+- **Relationships**: `aria-controls`, `aria-owns`, `aria-haspopup`
+- **Other**: `aria-current`, `aria-invalid`, `aria-required`
 
-  // States
-  "aria-expanded": boolean; // Expandable element state
-  "aria-selected": boolean; // Selection state
-  "aria-checked": boolean | "mixed"; // Checkbox/switch state
-  "aria-pressed": boolean | "mixed"; // Toggle button state
-  "aria-disabled": boolean; // Disabled state
-  "aria-hidden": boolean; // Hidden from assistive tech
-
-  // Live regions
-  "aria-live": "off" | "polite" | "assertive";
-  "aria-atomic": boolean;
-  "aria-relevant": string;
-
-  // Relationships
-  "aria-controls": string; // ID of controlled element
-  "aria-owns": string; // ID of owned elements
-  "aria-haspopup": boolean | "menu" | "dialog";
-
-  // Other
-  "aria-current": "page" | "step" | "location" | "date" | "time" | boolean;
-  "aria-invalid": boolean | "grammar" | "spelling";
-  "aria-required": boolean;
-}
-```
-
-#### ARIA Examples
+#### ARIA Pattern: Accessible Modal
 
 ```tsx
-// Accessible modal dialog
 function Modal({ isOpen, onClose, title, children }) {
   const titleId = useId();
-
   useEffect(() => {
     if (isOpen) {
-      // Trap focus inside modal
-      const focusableElements = modalRef.current.querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      const focusable = modalRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
       );
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-
-      firstElement?.focus();
-
-      const handleTab = (e: KeyboardEvent) => {
+      focusable[0]?.focus();
+      const handleKey = (e: KeyboardEvent) => {
         if (e.key === "Tab") {
-          if (e.shiftKey && document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement?.focus();
-          } else if (!e.shiftKey && document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement?.focus();
+          if (e.shiftKey && document.activeElement === focusable[0]) {
+            e.preventDefault(); focusable[focusable.length - 1]?.focus();
+          } else if (!e.shiftKey && document.activeElement === focusable[focusable.length - 1]) {
+            e.preventDefault(); focusable[0]?.focus();
           }
         }
-        if (e.key === "Escape") {
-          onClose();
-        }
+        if (e.key === "Escape") onClose();
       };
-
-      document.addEventListener("keydown", handleTab);
-      return () => document.removeEventListener("keydown", handleTab);
+      document.addEventListener("keydown", handleKey);
+      return () => document.removeEventListener("keydown", handleKey);
     }
   }, [isOpen, onClose]);
-
   if (!isOpen) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      ref={modalRef}
-    >
+    <div role="dialog" aria-modal="true" aria-labelledby={titleId} ref={modalRef}>
       <h2 id={titleId}>{title}</h2>
       {children}
-      <button onClick={onClose} aria-label="Close dialog">
-        Close
-      </button>
-    </div>
-  );
-}
-
-// Accessible tabs
-function Tabs({ tabs }) {
-  const [activeIndex, setActiveIndex] = useState(0);
-
-  const handleKeyDown = (e: KeyboardEvent, index: number) => {
-    let newIndex = index;
-
-    switch (e.key) {
-      case "ArrowRight":
-        newIndex = (index + 1) % tabs.length;
-        break;
-      case "ArrowLeft":
-        newIndex = (index - 1 + tabs.length) % tabs.length;
-        break;
-      case "Home":
-        newIndex = 0;
-        break;
-      case "End":
-        newIndex = tabs.length - 1;
-        break;
-      default:
-        return;
-    }
-
-    e.preventDefault();
-    setActiveIndex(newIndex);
-    document.getElementById(`tab-${newIndex}`)?.focus();
-  };
-
-  return (
-    <div>
-      <div role="tablist" aria-label="Content tabs">
-        {tabs.map((tab, index) => (
-          <button
-            key={index}
-            id={`tab-${index}`}
-            role="tab"
-            aria-selected={activeIndex === index}
-            aria-controls={`panel-${index}`}
-            tabIndex={activeIndex === index ? 0 : -1}
-            onClick={() => setActiveIndex(index)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {tabs.map((tab, index) => (
-        <div
-          key={index}
-          id={`panel-${index}`}
-          role="tabpanel"
-          aria-labelledby={`tab-${index}`}
-          hidden={activeIndex !== index}
-          tabIndex={0}
-        >
-          {tab.content}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Live region for dynamic updates
-function Notification({ message, type }) {
-  return (
-    <div
-      role="alert"
-      aria-live={type === "error" ? "assertive" : "polite"}
-      aria-atomic="true"
-    >
-      {message}
+      <button onClick={onClose} aria-label="Close dialog">Close</button>
     </div>
   );
 }
@@ -382,841 +130,177 @@ function Notification({ message, type }) {
 
 ### 4. Keyboard Navigation
 
-#### Standard Keyboard Patterns
+#### Standard Patterns
 
-| Pattern              | Keys           | Behavior                                                   |
-| -------------------- | -------------- | ---------------------------------------------------------- |
-| **Tab navigation**   | Tab, Shift+Tab | Move focus forward/backward through interactive elements   |
-| **Arrow navigation** | Arrow keys     | Navigate within composite widgets (menus, tabs, lists)     |
-| **Action keys**      | Enter, Space   | Activate buttons/links (Enter for both, Space for buttons) |
-| **Escape**           | Esc            | Close dialogs, cancel operations, exit modes               |
-| **Home/End**         | Home, End      | Move to first/last item in a group                         |
-| **Page Up/Down**     | PgUp, PgDn     | Scroll or navigate by page                                 |
-| **Type-ahead**       | Letter keys    | Find items by typing first letter                          |
+| Pattern | Keys | Behavior |
+|---------|------|----------|
+| **Tab navigation** | Tab / Shift+Tab | Move focus forward/backward through interactive elements |
+| **Arrow navigation** | Arrow keys | Navigate within composite widgets (menus, tabs, lists) |
+| **Action keys** | Enter / Space | Activate buttons and links |
+| **Escape** | Esc | Close dialogs, cancel operations |
+| **Home/End** | Home / End | Move to first/last item in a group |
 
-#### Common Widget Patterns
+#### Widget Keyboard Patterns
 
-**Tabs:**
+- **Tabs**: Arrow Left/Right between tabs, Home/End for first/last, Tab exits to panel
+- **Menu**: Arrow Up/Down for items, Arrow Right opens submenu, Escape closes
+- **Dialog**: Tab/Shift+Tab cycles (focus trap), Escape closes, focus returns to trigger
+- **Accordion**: Tab between headers, Enter/Space toggles panel
+- **Combobox**: Arrow Down opens listbox, Enter selects, Escape closes
 
-- Tab: Enter tab list
-- Arrow Left/Right: Navigate between tabs
-- Home/End: First/last tab
-- Tab: Exit to tab panel content
-
-**Menu:**
-
-- Arrow Up/Down: Navigate menu items
-- Arrow Right: Open submenu
-- Arrow Left: Close submenu
-- Home/End: First/last item
-- Escape: Close menu
-- Letter keys: Jump to item starting with letter
-
-**Dialog:**
-
-- Tab/Shift+Tab: Cycle through dialog elements (focus trap)
-- Escape: Close dialog
-- Focus returns to trigger element on close
-
-**Accordion:**
-
-- Tab: Move to next accordion header
-- Arrow Up/Down: Navigate accordion headers (optional)
-- Enter/Space: Toggle accordion panel
-- Home/End: First/last header (optional)
-
-**Combobox:**
-
-- Arrow Down: Open listbox
-- Arrow Up/Down: Navigate options
-- Enter: Select option and close
-- Escape: Close without selecting
-- Type-ahead: Filter/jump to options
-
-```tsx
-// Keyboard navigation utilities
-
-// Focus management hook
-function useFocusManagement() {
-  const focusableSelector = [
-    "a[href]",
-    "button:not([disabled])",
-    "input:not([disabled])",
-    "select:not([disabled])",
-    "textarea:not([disabled])",
-    '[tabindex]:not([tabindex="-1"])',
-  ].join(", ");
-
-  const getFocusableElements = (container: HTMLElement) => {
-    return Array.from(container.querySelectorAll(focusableSelector));
-  };
-
-  const trapFocus = (container: HTMLElement) => {
-    const elements = getFocusableElements(container);
-    const first = elements[0] as HTMLElement;
-    const last = elements[elements.length - 1] as HTMLElement;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== "Tab") return;
-
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first.focus();
-        }
-      }
-    };
-
-    container.addEventListener("keydown", handleKeyDown);
-    return () => container.removeEventListener("keydown", handleKeyDown);
-  };
-
-  return { getFocusableElements, trapFocus };
-}
-
-// Roving tabindex for grouped elements
-function useRovingTabindex<T extends HTMLElement>(
-  items: T[],
-  options: { orientation: "horizontal" | "vertical" | "both" } = {
-    orientation: "horizontal",
-  },
-) {
-  const [focusedIndex, setFocusedIndex] = useState(0);
-
-  const handleKeyDown = (e: KeyboardEvent, index: number) => {
-    const { orientation } = options;
-    let newIndex = index;
-
-    const prevKeys = orientation === "vertical" ? ["ArrowUp"] : ["ArrowLeft"];
-    const nextKeys =
-      orientation === "vertical" ? ["ArrowDown"] : ["ArrowRight"];
-
-    if (orientation === "both") {
-      prevKeys.push("ArrowUp", "ArrowLeft");
-      nextKeys.push("ArrowDown", "ArrowRight");
-    }
-
-    if (prevKeys.includes(e.key)) {
-      newIndex = (index - 1 + items.length) % items.length;
-    } else if (nextKeys.includes(e.key)) {
-      newIndex = (index + 1) % items.length;
-    } else if (e.key === "Home") {
-      newIndex = 0;
-    } else if (e.key === "End") {
-      newIndex = items.length - 1;
-    } else {
-      return;
-    }
-
-    e.preventDefault();
-    setFocusedIndex(newIndex);
-    items[newIndex]?.focus();
-  };
-
-  return {
-    focusedIndex,
-    getTabIndex: (index: number) => (index === focusedIndex ? 0 : -1),
-    handleKeyDown,
-  };
-}
-
-// Skip link component
-function SkipLink({ targetId, children = "Skip to main content" }) {
-  return (
-    <a
-      href={`#${targetId}`}
-      className="skip-link"
-      style={{
-        position: "absolute",
-        left: "-9999px",
-        top: "auto",
-        width: "1px",
-        height: "1px",
-        overflow: "hidden",
-      }}
-      onFocus={(e) => {
-        e.currentTarget.style.left = "0";
-        e.currentTarget.style.width = "auto";
-        e.currentTarget.style.height = "auto";
-      }}
-      onBlur={(e) => {
-        e.currentTarget.style.left = "-9999px";
-        e.currentTarget.style.width = "1px";
-        e.currentTarget.style.height = "1px";
-      }}
-    >
-      {children}
-    </a>
-  );
-}
-```
-
-### 5. Screen Reader Testing
-
-#### Screen Reader Reference
-
-| Reader        | Platform  | Cost     | Enable         | Key Shortcuts                                                                                                   |
-| ------------- | --------- | -------- | -------------- | --------------------------------------------------------------------------------------------------------------- |
-| **NVDA**      | Windows   | Free     | Auto-start     | Start: NVDA+Down, Stop: Ctrl, Next heading: H, Next link: K, Next form: F, Landmarks: D, Elements list: NVDA+F7 |
-| **JAWS**      | Windows   | Paid     | Auto-start     | Start: Insert+Down, Stop: Ctrl, Next heading: H, Headings list: Insert+F6                                       |
-| **VoiceOver** | macOS/iOS | Built-in | Cmd+F5         | Next: VO+Right, Previous: VO+Left, Rotor: VO+U, Activate: VO+Space                                              |
-| **TalkBack**  | Android   | Built-in | Settings       | Next: Swipe right, Previous: Swipe left, Activate: Double tap, Scroll: Two-finger swipe                         |
-| **Narrator**  | Windows   | Built-in | Ctrl+Win+Enter | Scan mode: Caps Lock+Space, Next heading: H, Next link: K                                                       |
-
-#### Screen Reader Testing Checklist
-
-**Navigation:**
-
-- Page title announces on load
-- Headings create logical outline (h1 → h6 hierarchy maintained)
-- Landmark regions are properly labeled (banner, navigation, main, complementary, contentinfo)
-- Skip links allow bypassing repetitive content
-- Focus order follows visual reading order
-
-**Content:**
-
-- All images have appropriate alt text (decorative images have empty alt="")
-- Links have descriptive text (avoid "click here")
-- Buttons clearly indicate their action
-- Dynamic content updates are announced (aria-live regions)
-- Tables have proper headers and captions
-
-**Forms:**
-
-- Form labels are properly associated with inputs
-- Error messages are associated with form fields (aria-describedby)
-- Required fields indicated (aria-required)
-- Invalid fields indicated (aria-invalid)
-- Error summary announced on submit
-
-**Interactions:**
-
-- Modal focus is trapped inside dialog
-- Modal announces its role and label
-- Keyboard shortcuts don't conflict with screen reader shortcuts
-- Custom widgets announce state changes (aria-expanded, aria-selected)
+#### Focus Management Essentials
 
 ```typescript
-// Screen reader testing utilities
-
-const screenReaderTesting = {
-  // Common screen readers
-  readers: {
-    nvda: {
-      platform: "Windows",
-      cost: "Free",
-      shortcuts: {
-        startReading: "NVDA + Down Arrow",
-        stopReading: "Ctrl",
-        nextHeading: "H",
-        nextLink: "K",
-        nextFormField: "F",
-        nextLandmark: "D",
-        elementsList: "NVDA + F7",
-      },
-    },
-    jaws: {
-      platform: "Windows",
-      cost: "Paid",
-      shortcuts: {
-        startReading: "Insert + Down Arrow",
-        stopReading: "Ctrl",
-        nextHeading: "H",
-        nextLink: "Tab",
-        headingsList: "Insert + F6",
-      },
-    },
-    voiceover: {
-      platform: "macOS/iOS",
-      cost: "Built-in",
-      shortcuts: {
-        toggle: "Cmd + F5",
-        nextElement: "VO + Right Arrow",
-        previousElement: "VO + Left Arrow",
-        rotor: "VO + U",
-        activate: "VO + Space",
-      },
-    },
-    talkback: {
-      platform: "Android",
-      cost: "Built-in",
-      gestures: {
-        nextElement: "Swipe Right",
-        previousElement: "Swipe Left",
-        activate: "Double Tap",
-        scrollForward: "Two finger swipe up",
-      },
-    },
-  },
-};
-
-// Announce utility for screen readers
-function announce(
-  message: string,
-  priority: "polite" | "assertive" = "polite",
-) {
-  const announcer = document.createElement("div");
-  announcer.setAttribute("aria-live", priority);
-  announcer.setAttribute("aria-atomic", "true");
-  announcer.setAttribute("class", "sr-only");
-  announcer.style.cssText = `
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  `;
-
-  document.body.appendChild(announcer);
-
-  // Delay to ensure screen reader picks up the change
-  setTimeout(() => {
-    announcer.textContent = message;
-  }, 100);
-
-  // Clean up
-  setTimeout(() => {
-    document.body.removeChild(announcer);
-  }, 1000);
-}
-
-// Usage
-announce("Form submitted successfully");
-announce("Error: Please fill in all required fields", "assertive");
-```
-
-### 6. Color Contrast and Visual Accessibility
-
-```typescript
-// Color contrast utilities
-
-function getLuminance(r: number, g: number, b: number): number {
-  const [rs, gs, bs] = [r, g, b].map((c) => {
-    c = c / 255;
-    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
-  });
-  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
-}
-
-function getContrastRatio(color1: string, color2: string): number {
-  const rgb1 = hexToRgb(color1);
-  const rgb2 = hexToRgb(color2);
-
-  const l1 = getLuminance(rgb1.r, rgb1.g, rgb1.b);
-  const l2 = getLuminance(rgb2.r, rgb2.g, rgb2.b);
-
-  const lighter = Math.max(l1, l2);
-  const darker = Math.min(l1, l2);
-
-  return (lighter + 0.05) / (darker + 0.05);
-}
-
-function hexToRgb(hex: string): { r: number; g: number; b: number } {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  return result
-    ? {
-        r: parseInt(result[1], 16),
-        g: parseInt(result[2], 16),
-        b: parseInt(result[3], 16),
-      }
-    : { r: 0, g: 0, b: 0 };
-}
-
-function meetsWCAGContrast(
-  foreground: string,
-  background: string,
-  level: "AA" | "AAA" = "AA",
-  isLargeText: boolean = false,
-): boolean {
-  const ratio = getContrastRatio(foreground, background);
-
-  const requirements = {
-    AA: { normal: 4.5, large: 3 },
-    AAA: { normal: 7, large: 4.5 },
-  };
-
-  const required = requirements[level][isLargeText ? "large" : "normal"];
-  return ratio >= required;
-}
-
-// Usage
-const passes = meetsWCAGContrast("#333333", "#ffffff", "AA");
-console.log(
-  `Contrast ratio: ${getContrastRatio("#333333", "#ffffff").toFixed(2)}:1`,
-);
-
-// Accessible color palette generator
-function generateAccessiblePalette(
-  baseColor: string,
-  background: string = "#ffffff",
-) {
-  const shades = [];
-  const rgb = hexToRgb(baseColor);
-
-  for (let i = 0; i <= 100; i += 10) {
-    const factor = i / 100;
-    const shade = {
-      r: Math.round(rgb.r * factor),
-      g: Math.round(rgb.g * factor),
-      b: Math.round(rgb.b * factor),
-    };
-    const hex = `#${shade.r.toString(16).padStart(2, "0")}${shade.g.toString(16).padStart(2, "0")}${shade.b.toString(16).padStart(2, "0")}`;
-    const ratio = getContrastRatio(hex, background);
-
-    shades.push({
-      shade: i,
-      hex,
-      contrastRatio: ratio.toFixed(2),
-      passesAA: ratio >= 4.5,
-      passesAAA: ratio >= 7,
-    });
-  }
-
-  return shades;
-}
-
-// Focus visible styles
-const focusStyles = `
-  /* Remove default outline */
-  :focus {
-    outline: none;
-  }
-
-  /* Add visible focus for keyboard users */
-  :focus-visible {
-    outline: 2px solid #005fcc;
-    outline-offset: 2px;
-  }
-
-  /* High contrast mode support */
-  @media (prefers-contrast: high) {
-    :focus-visible {
-      outline: 3px solid currentColor;
-      outline-offset: 3px;
-    }
-  }
-
-  /* Reduced motion support */
-  @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
-    }
-  }
-`;
-```
-
-### 7. Automated A11y Testing Tools
-
-```typescript
-// Automated accessibility testing setup
-
-// Jest + Testing Library
-import { render, screen } from '@testing-library/react';
-import { axe, toHaveNoViolations } from 'jest-axe';
-
-expect.extend(toHaveNoViolations);
-
-describe('Accessibility Tests', () => {
-  it('should have no accessibility violations', async () => {
-    const { container } = render(<MyComponent />);
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
-
-  it('should have accessible form', () => {
-    render(<LoginForm />);
-
-    // Check for proper labels
-    expect(screen.getByLabelText('Email')).toBeInTheDocument();
-    expect(screen.getByLabelText('Password')).toBeInTheDocument();
-
-    // Check for proper roles
-    expect(screen.getByRole('form')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Sign In' })).toBeInTheDocument();
-  });
-
-  it('should manage focus correctly', () => {
-    render(<Modal isOpen={true} />);
-
-    // First focusable element should be focused
-    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close' }));
-  });
-});
-
-// Playwright accessibility testing
-import { test, expect } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
-
-test.describe('Accessibility', () => {
-  test('homepage should not have accessibility issues', async ({ page }) => {
-    await page.goto('/');
-
-    const accessibilityScanResults = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
-      .analyze();
-
-    expect(accessibilityScanResults.violations).toEqual([]);
-  });
-
-  test('should be navigable by keyboard', async ({ page }) => {
-    await page.goto('/');
-
-    // Tab to skip link
-    await page.keyboard.press('Tab');
-    await expect(page.getByText('Skip to main content')).toBeFocused();
-
-    // Tab to navigation
-    await page.keyboard.press('Tab');
-    await expect(page.getByRole('link', { name: 'Home' })).toBeFocused();
-  });
-});
-
-// CI/CD integration for accessibility
-const accessibilityConfig = {
-  // Lighthouse CI config
-  lighthouse: {
-    assertions: {
-      'categories:accessibility': ['error', { minScore: 0.9 }],
-      'color-contrast': 'error',
-      'document-title': 'error',
-      'html-has-lang': 'error',
-      'image-alt': 'error',
-      'label': 'error',
-      'link-name': 'error',
-      'meta-viewport': 'error',
-    },
-  },
-
-  // Pa11y CI config
-  pa11y: {
-    standard: 'WCAG2AA',
-    runners: ['axe', 'htmlcs'],
-    ignore: [
-      'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail', // Ignore specific rules if needed
-    ],
-  },
-
-  // Axe configuration
-  axe: {
-    runOnly: {
-      type: 'tag',
-      values: ['wcag2a', 'wcag2aa', 'wcag21aa', 'best-practice'],
-    },
-    rules: {
-      'color-contrast': { enabled: true },
-      'valid-lang': { enabled: true },
-    },
-  },
-};
-```
-
-## Best Practices
-
-1. **Start with Semantic HTML**: Proper HTML elements provide built-in accessibility. Use button for buttons, a for links, nav for navigation, etc.
-
-2. **First Rule of ARIA**: Don't use ARIA if semantic HTML can do it. ARIA fixes what HTML can't express.
-
-3. **Maintain Focus Management**: Ensure logical focus order, visible focus indicators, and proper focus trapping in modals.
-
-4. **Keyboard First**: All functionality must work with keyboard only. Test by unplugging your mouse.
-
-5. **Test with Real Tools**: Use screen readers (NVDA, VoiceOver), keyboard only, and automated tools (axe, Lighthouse).
-
-6. **Provide Text Alternatives**: All images need alt text (or empty alt="" for decorative), videos need captions.
-
-7. **Design for Inclusion**: Consider color blindness, low vision, motor disabilities, cognitive disabilities from the start.
-
-8. **Progressive Enhancement**: Core functionality should work without JavaScript. Enhanced experience for capable browsers.
-
-9. **Test Early and Often**: Accessibility is easier to build in than bolt on. Include in every code review.
-
-10. **Learn from Users**: Include people with disabilities in user testing when possible.
-
-## Examples
-
-### Complete Accessible Form
-
-```tsx
-function AccessibleForm() {
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const errorSummaryRef = useRef<HTMLDivElement>(null);
-
-  const handleSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    const newErrors: Record<string, string> = {};
-
-    // Validation
-    if (!formData.email) {
-      newErrors.email = "Email is required";
-    }
-    if (!formData.password) {
-      newErrors.password = "Password is required";
-    }
-
-    if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors);
-      // Focus error summary for screen readers
-      errorSummaryRef.current?.focus();
-      announce(
-        "Form has errors. Please correct them and try again.",
-        "assertive",
-      );
-    } else {
-      // Submit form
-      announce("Form submitted successfully", "polite");
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit} aria-labelledby="form-title" noValidate>
-      <h1 id="form-title">Sign Up</h1>
-
-      {Object.keys(errors).length > 0 && (
-        <div
-          ref={errorSummaryRef}
-          role="alert"
-          aria-labelledby="error-summary-title"
-          tabIndex={-1}
-          className="error-summary"
-        >
-          <h2 id="error-summary-title">There are errors in the form</h2>
-          <ul>
-            {Object.entries(errors).map(([field, message]) => (
-              <li key={field}>
-                <a href={`#${field}`}>{message}</a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      <div className="form-field">
-        <label htmlFor="email">
-          Email address
-          <span aria-hidden="true">*</span>
-          <span className="sr-only">(required)</span>
-        </label>
-        <input
-          type="email"
-          id="email"
-          name="email"
-          autoComplete="email"
-          aria-required="true"
-          aria-invalid={!!errors.email}
-          aria-describedby={errors.email ? "email-error" : undefined}
-        />
-        {errors.email && (
-          <span id="email-error" role="alert" className="error">
-            {errors.email}
-          </span>
-        )}
-      </div>
-
-      <div className="form-field">
-        <label htmlFor="password">
-          Password
-          <span aria-hidden="true">*</span>
-          <span className="sr-only">(required)</span>
-        </label>
-        <input
-          type="password"
-          id="password"
-          name="password"
-          autoComplete="new-password"
-          aria-required="true"
-          aria-invalid={!!errors.password}
-          aria-describedby="password-hint password-error"
-        />
-        <span id="password-hint" className="hint">
-          Must be at least 8 characters
-        </span>
-        {errors.password && (
-          <span id="password-error" role="alert" className="error">
-            {errors.password}
-          </span>
-        )}
-      </div>
-
-      <button type="submit">Create Account</button>
-    </form>
-  );
-}
-```
-
-## Quick Reference
-
-### Common ARIA Patterns Cheat Sheet
-
-```typescript
-// Button
-<button type="button">Click me</button>
-
-// Toggle button
-<button aria-pressed="true">Mute</button>
-
-// Icon button
-<button aria-label="Close">×</button>
-
-// Link that looks like button (DON'T - use button instead)
-// If you must: <a href="#" role="button" aria-pressed="false">
-
-// Disabled state
-<button disabled>Cannot click</button>
-<button aria-disabled="true">Visually disabled but focusable</button>
-
-// Loading state
-<button aria-busy="true">Saving...</button>
-
-// Expandable section
-<button aria-expanded="false" aria-controls="panel-id">Toggle</button>
-<div id="panel-id" hidden>Content</div>
-
-// Custom checkbox
-<div role="checkbox" aria-checked="false" tabindex="0">Option</div>
-
-// Modal dialog
-<div role="dialog" aria-modal="true" aria-labelledby="title-id">
-  <h2 id="title-id">Dialog Title</h2>
-</div>
-
-// Alert (announces immediately)
-<div role="alert">Error: Form submission failed</div>
-
-// Status (announces after current utterance)
-<div role="status" aria-live="polite">5 new messages</div>
-
-// Tabs
-<div role="tablist">
-  <button role="tab" aria-selected="true" aria-controls="panel1">Tab 1</button>
-  <button role="tab" aria-selected="false" aria-controls="panel2">Tab 2</button>
-</div>
-<div id="panel1" role="tabpanel">Panel 1 content</div>
-<div id="panel2" role="tabpanel" hidden>Panel 2 content</div>
-
-// Form field with description and error
-<label for="email">Email</label>
-<input
-  id="email"
-  type="email"
-  aria-describedby="email-hint email-error"
-  aria-invalid="true"
-  aria-required="true"
-/>
-<span id="email-hint">We'll never share your email</span>
-<span id="email-error" role="alert">Please enter a valid email</span>
-
-// Visually hidden but available to screen readers
-<span className="sr-only">Screen reader only text</span>
-// CSS: .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; }
-
-// Hidden from screen readers
-<div aria-hidden="true">Decorative content</div>
-```
-
-### Alt Text Guidelines
-
-```typescript
-// Informative images - describe the information
-<img src="chart.png" alt="Sales increased 25% from Q1 to Q2" />
-
-// Functional images - describe the action
-<img src="print-icon.png" alt="Print this page" />
-
-// Decorative images - empty alt
-<img src="decorative-border.png" alt="" />
-
-// Complex images - use long description
-<img
-  src="complex-diagram.png"
-  alt="System architecture diagram"
-  aria-describedby="diagram-desc"
-/>
-<div id="diagram-desc">
-  Detailed description: The system consists of...
-</div>
-
-// Images of text - avoid if possible, otherwise copy the text
-<img src="logo.png" alt="Acme Corporation" />
-
-// Background images - use empty alt, provide text alternative elsewhere
-<div style="background-image: url(hero.jpg)" role="img" aria-label="Team celebrating">
-```
-
-### Focus Management Patterns
-
-```typescript
-// Focus trap (modal, sidebar)
-// 1. Save previously focused element
-const previousFocus = document.activeElement;
-
-// 2. Focus first element in trap
-modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')?.focus();
-
-// 3. On Tab, cycle within trap
-// See useFocusManagement hook above
-
-// 4. On close, restore focus
-previousFocus?.focus();
-
-// Roving tabindex (toolbar, menu)
-// Only one item in group has tabindex="0", rest have tabindex="-1"
-// Arrow keys move focus and update tabindex values
+// Focus trap pattern
+const previousFocus = document.activeElement;  // 1. Save previous focus
+modal.querySelector('button, [href], input')?.focus();  // 2. Focus first element
+// 3. On Tab, cycle within trap (see Modal example above)
+previousFocus?.focus();  // 4. On close, restore focus
+
+// Roving tabindex: only active item has tabindex="0", rest have "-1"
 <div role="toolbar">
   <button tabindex="0">Cut</button>
   <button tabindex="-1">Copy</button>
   <button tabindex="-1">Paste</button>
 </div>
 
-// Skip link (first focusable element)
+// Skip link (first focusable element on page)
 <a href="#main-content" className="skip-link">Skip to main content</a>
 <main id="main-content" tabindex="-1">...</main>
+```
 
-// Focus management after deletion
-// Focus next item, or previous if last, or container if empty
-listItems.splice(index, 1);
-if (listItems[index]) {
-  listItems[index].focus();
-} else if (listItems[index - 1]) {
-  listItems[index - 1].focus();
-} else {
-  containerElement.focus();
+### 5. Screen Reader Testing
+
+| Reader | Platform | Shortcuts |
+|--------|----------|-----------|
+| **NVDA** | Windows (Free) | Start: NVDA+Down, Next heading: H, Landmarks: D, Elements list: NVDA+F7 |
+| **VoiceOver** | macOS (Built-in) | Toggle: Cmd+F5, Next: VO+Right, Rotor: VO+U, Activate: VO+Space |
+| **TalkBack** | Android (Built-in) | Next: Swipe right, Activate: Double tap |
+
+**Screen reader checklist**:
+
+- Page title announces on load; headings create logical h1-h6 hierarchy
+- Landmark regions are labeled; skip links bypass repetitive content
+- All images have appropriate alt text; links have descriptive text
+- Dynamic updates announced via `aria-live` regions
+- Form labels associated with inputs; errors linked via `aria-describedby`
+- Modal focus trapped; custom widgets announce state changes
+
+### 6. Color Contrast and Visual Accessibility
+
+**WCAG contrast requirements**:
+
+| Level | Normal text | Large text (18pt+ or 14pt bold) |
+|-------|------------|--------------------------------|
+| AA | 4.5:1 | 3:1 |
+| AAA | 7:1 | 4.5:1 |
+
+**Essential CSS for visual accessibility**:
+
+```css
+/* Visible focus for keyboard users */
+:focus-visible {
+  outline: 2px solid #005fcc;
+  outline-offset: 2px;
+}
+/* High contrast mode */
+@media (prefers-contrast: high) {
+  :focus-visible { outline: 3px solid currentColor; outline-offset: 3px; }
+}
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 ```
 
-### Testing Checklist
+### 7. Automated Testing
 
-**Automated (Run on every PR):**
+```typescript
+// Jest + axe-core
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
 
-- axe-core (via jest-axe or @axe-core/playwright)
-- Lighthouse accessibility score
-- ESLint plugin: eslint-plugin-jsx-a11y
+it('has no a11y violations', async () => {
+  const { container } = render(<MyComponent />);
+  expect(await axe(container)).toHaveNoViolations();
+});
 
-**Manual (Run before release):**
+// Playwright + axe
+import AxeBuilder from '@axe-core/playwright';
+test('no a11y issues', async ({ page }) => {
+  await page.goto('/');
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21aa']).analyze();
+  expect(results.violations).toEqual([]);
+});
+```
 
-- Keyboard only navigation (unplug mouse)
-- Screen reader testing (NVDA/VoiceOver)
-- Browser zoom to 200%
-- Color contrast checker (WCAG AA minimum)
-- Tab through entire application
-- Check focus indicators visible
-- Test with reduced motion preference
-- Test with high contrast mode
+## Best Practices
 
-**Browser DevTools:**
+1. **Start with semantic HTML** — proper elements provide built-in accessibility
+2. **First rule of ARIA** — do not use ARIA if semantic HTML can do it
+3. **Maintain focus management** — logical focus order, visible indicators, focus trapping in modals
+4. **Keyboard first** — all functionality must work without a mouse
+5. **Test with real tools** — screen readers (NVDA, VoiceOver), keyboard only, axe, Lighthouse
+6. **Provide text alternatives** — all images need alt text (empty `alt=""` for decorative)
+7. **Design for inclusion** — consider color blindness, low vision, motor and cognitive disabilities
+8. **Test early and often** — include accessibility checks in every code review
 
-- Chrome: Lighthouse, Accessibility tree view
-- Firefox: Accessibility inspector
-- Safari: Accessibility audit
+## Quick Reference: Common ARIA Patterns
+
+```html
+<!-- Toggle button -->
+<button aria-pressed="true">Mute</button>
+
+<!-- Icon button (always needs label) -->
+<button aria-label="Close">x</button>
+
+<!-- Expandable section -->
+<button aria-expanded="false" aria-controls="panel-id">Toggle</button>
+<div id="panel-id" hidden>Content</div>
+
+<!-- Alert (announces immediately) -->
+<div role="alert">Error: Form submission failed</div>
+
+<!-- Status (announces politely) -->
+<div role="status" aria-live="polite">5 new messages</div>
+
+<!-- Tabs -->
+<div role="tablist">
+  <button role="tab" aria-selected="true" aria-controls="p1">Tab 1</button>
+  <button role="tab" aria-selected="false" aria-controls="p2">Tab 2</button>
+</div>
+<div id="p1" role="tabpanel">Panel 1</div>
+<div id="p2" role="tabpanel" hidden>Panel 2</div>
+
+<!-- Form field with error -->
+<label for="email">Email</label>
+<input id="email" type="email" aria-describedby="hint err" aria-invalid="true" aria-required="true" />
+<span id="hint">We will never share your email</span>
+<span id="err" role="alert">Please enter a valid email</span>
+
+<!-- Visually hidden (screen reader only) -->
+<span class="sr-only">Screen reader text</span>
+<!-- CSS: .sr-only { position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0); } -->
+
+<!-- Hidden from screen readers -->
+<div aria-hidden="true">Decorative content</div>
+```
+
+## Alt Text Guidelines
+
+- **Informative images**: describe the information (`alt="Sales increased 25% Q1 to Q2"`)
+- **Functional images**: describe the action (`alt="Print this page"`)
+- **Decorative images**: empty alt (`alt=""`)
+- **Complex images**: use `aria-describedby` pointing to a detailed description
+- **Images of text**: avoid when possible; otherwise reproduce the text in alt
+
+## Testing Checklist
+
+**Automated (every PR)**: axe-core, Lighthouse accessibility score, eslint-plugin-jsx-a11y
+
+**Manual (before release)**: keyboard-only navigation, screen reader testing, 200% browser zoom, color contrast check, focus indicator visibility, reduced motion and high contrast mode

--- a/skills/loom-api-design/SKILL.md
+++ b/skills/loom-api-design/SKILL.md
@@ -1,89 +1,65 @@
 ---
 name: loom-api-design
-description: Designs RESTful APIs, GraphQL schemas, and RPC interfaces following best practices for consistency, usability, and scalability. Trigger keywords: api design, REST, RESTful, REST API, GraphQL, GraphQL schema, gRPC, OpenAPI, Swagger, endpoint, route, resource, CRUD, HTTP method, GET, POST, PUT, PATCH, DELETE, status code, pagination, filtering, sorting, versioning, HATEOAS, API versioning, schema design, RPC, service design.
+description: "Designs RESTful APIs, GraphQL schemas, and gRPC interfaces following best practices for consistency, usability, and scalability. Use when the developer needs to create or refactor API endpoints, define resource models, plan versioning strategies, or design request/response schemas across REST, GraphQL, or gRPC protocols."
 allowed-tools: Read, Grep, Glob, Edit, Write
+trigger-keywords: api design, REST, RESTful, REST API, GraphQL, GraphQL schema, gRPC, OpenAPI, Swagger, endpoint, route, resource, CRUD, HTTP method, GET, POST, PUT, PATCH, DELETE, status code, pagination, filtering, sorting, versioning, HATEOAS, API versioning, schema design, RPC, service design
 ---
 
 # API Design
 
 ## Overview
 
-This skill guides the design of well-structured APIs that are intuitive, consistent, and scalable. It covers REST, GraphQL, and gRPC patterns with focus on developer experience and long-term maintainability.
+This skill guides the agent through designing well-structured APIs that are intuitive, consistent, and scalable. It covers REST, GraphQL, and gRPC patterns with focus on developer experience and long-term maintainability.
 
-## Instructions
+## Workflow
 
-### 1. Understand Requirements
+The agent follows these steps when designing or reviewing an API:
 
-- Identify API consumers and use cases
-- Define resource models and relationships
-- Determine authentication/authorization needs
-- Plan for versioning strategy
-
-### 2. Design Resource Structure
-
-- Define clear resource hierarchies
-- Establish naming conventions
-- Plan URL patterns
-- Design request/response schemas
-
-### 3. Define Operations
-
-- Map CRUD operations to HTTP methods
-- Design query parameters for filtering/sorting
-- Plan pagination approach
-- Define error response formats
-
-### 4. Document the API
-
-- Create OpenAPI/Swagger specification
-- Include examples for all endpoints
-- Document authentication flows
-- Provide SDK usage examples
+1. **Understand requirements** — Identify API consumers, use cases, resource models, relationships, and authentication/authorization needs. Determine the versioning strategy early.
+2. **Design resource structure** — Define clear resource hierarchies, establish naming conventions, plan URL patterns, and design request/response schemas.
+3. **Define operations** — Map CRUD operations to HTTP methods (REST), define queries and mutations (GraphQL), or specify RPC methods (gRPC). Plan filtering, sorting, pagination, and error response formats.
+4. **Document the API** — Create an OpenAPI/Swagger specification (REST), schema documentation (GraphQL), or proto file comments (gRPC). Include examples for all endpoints and document authentication flows.
+5. **Review and validate** — Check adherence to the best practices below. Verify consistency in naming, status codes, error formats, and pagination across all endpoints.
 
 ## Best Practices
 
 ### RESTful API Design
 
-1. **Use Nouns for Resources**: `/users`, not `/getUsers`
-2. **Consistent Naming**: Use snake_case or camelCase consistently across all endpoints
-3. **Proper HTTP Methods**:
-   - GET (read/fetch), POST (create), PUT (full update), PATCH (partial update), DELETE (remove)
-4. **Meaningful Status Codes**:
-   - 200 (OK), 201 (Created), 204 (No Content)
-   - 400 (Bad Request), 401 (Unauthorized), 403 (Forbidden), 404 (Not Found)
-   - 409 (Conflict), 422 (Unprocessable Entity)
-   - 500 (Internal Server Error), 503 (Service Unavailable)
-5. **Idempotency**: PUT and DELETE should be idempotent; consider idempotency keys for POST
-6. **HATEOAS**: Include links to related resources in responses
-7. **Filtering & Sorting**: Use query parameters (`?status=active&sort=-created_at`)
-8. **Pagination**: Cursor-based for large datasets, offset for simpler cases
+1. **Use nouns for resources** — `/users`, not `/getUsers`.
+2. **Consistent naming** — Use snake_case or camelCase consistently across all endpoints.
+3. **Proper HTTP methods** — GET (read), POST (create), PUT (full update), PATCH (partial update), DELETE (remove).
+4. **Meaningful status codes** — 200 OK, 201 Created, 204 No Content, 400 Bad Request, 401 Unauthorized, 403 Forbidden, 404 Not Found, 409 Conflict, 422 Unprocessable Entity, 500 Internal Server Error, 503 Service Unavailable.
+5. **Idempotency** — PUT and DELETE must be idempotent. Consider idempotency keys for POST.
+6. **HATEOAS** — Include links to related resources in responses.
+7. **Filtering and sorting** — Use query parameters (e.g. `?status=active&sort=-created_at`).
+8. **Pagination** — Cursor-based for large datasets, offset-based for simpler cases.
 
 ### GraphQL Schema Design
 
-1. **Use Descriptive Types**: Clear, self-documenting type and field names
-2. **Connection Pattern**: Use relay-style connections for paginated lists
-3. **Input Objects**: Separate input types for mutations (CreateUserInput, UpdateUserInput)
-4. **Error Handling**: Return errors as part of payload, not just top-level exceptions
-5. **Nullability**: Be explicit about nullable vs non-nullable fields
-6. **Mutations Return Payloads**: Include both data and errors in mutation responses
-7. **Avoid Over-fetching**: Design fragments and fields for common query patterns
+1. **Use descriptive types** — Clear, self-documenting type and field names.
+2. **Connection pattern** — Use Relay-style connections for paginated lists.
+3. **Input objects** — Separate input types for mutations (CreateUserInput, UpdateUserInput).
+4. **Error handling** — Return errors as part of the payload, not just top-level exceptions.
+5. **Nullability** — Be explicit about nullable vs non-nullable fields.
+6. **Mutations return payloads** — Include both data and errors in mutation responses.
+7. **Avoid over-fetching** — Design fragments and fields for common query patterns.
 
 ### gRPC Service Design
 
-1. **Service Naming**: Use verbs for RPC methods (CreateUser, GetUser, ListUsers)
-2. **Message Reuse**: Define shared message types for common patterns
-3. **Pagination**: Use page_token pattern for cursor-based pagination
-4. **Errors**: Use google.rpc.Status for rich error details
-5. **Versioning**: Use package versioning (myapi.v1, myapi.v2)
-6. **Streaming**: Leverage server/client/bidirectional streaming where appropriate
+1. **Service naming** — Use verbs for RPC methods (CreateUser, GetUser, ListUsers).
+2. **Message reuse** — Define shared message types for common patterns.
+3. **Pagination** — Use the page_token pattern for cursor-based pagination.
+4. **Errors** — Use google.rpc.Status for rich error details.
+5. **Versioning** — Use package versioning (myapi.v1, myapi.v2).
+6. **Streaming** — Leverage server, client, or bidirectional streaming where appropriate.
 
 ### API Versioning Strategies
 
-1. **URL Path Versioning**: `/v1/users`, `/v2/users` (explicit, simple, cacheable)
-2. **Header Versioning**: `API-Version: 2` or `Accept: application/vnd.api.v2+json` (cleaner URLs)
-3. **Query Parameter**: `?version=2` (fallback option, less recommended)
-4. **Semantic Versioning**: Major versions for breaking changes, minor for features, patch for fixes
-5. **Deprecation Policy**: Announce sunset dates, support N-1 versions minimum
+1. **URL path versioning** — `/v1/users`, `/v2/users` (explicit, simple, cacheable).
+2. **Header versioning** — `API-Version: 2` or `Accept: application/vnd.api.v2+json` (cleaner URLs).
+3. **Query parameter** — `?version=2` (fallback option, less recommended).
+4. **Semantic versioning** — Major versions for breaking changes, minor for features, patch for fixes.
+5. **Deprecation policy** — Announce sunset dates and support N-1 versions minimum.
 
 ## Examples
 
@@ -169,26 +145,18 @@ paths:
 
 ```graphql
 type Query {
-  """
-  Fetch a user by ID
-  """
+  """Fetch a user by ID"""
   user(id: ID!): User
 
-  """
-  List users with optional filtering
-  """
+  """List users with optional filtering"""
   users(filter: UserFilter, first: Int = 20, after: String): UserConnection!
 }
 
 type Mutation {
-  """
-  Create a new user account
-  """
+  """Create a new user account"""
   createUser(input: CreateUserInput!): CreateUserPayload!
 
-  """
-  Update an existing user
-  """
+  """Update an existing user"""
   updateUser(id: ID!, input: UpdateUserInput!): UpdateUserPayload!
 }
 
@@ -222,25 +190,15 @@ type UserError {
 
 ```protobuf
 syntax = "proto3";
-
 package ecommerce.v1;
 
 import "google/protobuf/timestamp.proto";
 
 service ProductService {
-  // Fetch a single product by ID
   rpc GetProduct(GetProductRequest) returns (GetProductResponse);
-
-  // List products with filtering and pagination
   rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
-
-  // Create a new product
   rpc CreateProduct(CreateProductRequest) returns (CreateProductResponse);
-
-  // Update an existing product
   rpc UpdateProduct(UpdateProductRequest) returns (UpdateProductResponse);
-
-  // Delete a product
   rpc DeleteProduct(DeleteProductRequest) returns (DeleteProductResponse);
 }
 
@@ -255,16 +213,9 @@ message Product {
 }
 
 message ListProductsRequest {
-  // Optional category filter
   string category = 1;
-
-  // Minimum price filter (in cents)
   optional int64 min_price_cents = 2;
-
-  // Maximum number of items to return
   int32 page_size = 3;
-
-  // Page token from previous response
   string page_token = 4;
 }
 

--- a/skills/loom-debugging/SKILL.md
+++ b/skills/loom-debugging/SKILL.md
@@ -1,234 +1,96 @@
 ---
 name: loom-debugging
-description: Systematically diagnoses and resolves software bugs, test failures, data quality issues, and performance problems using various debugging techniques and tools. Trigger keywords: debug, bug, error, exception, crash, issue, troubleshoot, fix, stack trace, diagnosis, diagnose, investigate, root cause, why, failing, broken, not working, unexpected, flaky, intermittent, regression, performance degradation.
+description: "Systematically diagnoses and resolves software bugs, test failures, data quality issues, and performance problems. Use when the developer needs to debug crashes, flaky tests, data pipeline errors, ML model degradation, or trace root causes across application code and infrastructure."
 allowed-tools: Read, Grep, Glob, Bash, Edit
+trigger-keywords: debug, bug, error, exception, crash, issue, troubleshoot, fix, stack trace, diagnosis, diagnose, investigate, root cause, why, failing, broken, not working, unexpected, flaky, intermittent, regression, performance degradation
 ---
 
 # Debugging
 
 ## Overview
 
-This skill provides systematic approaches to finding and fixing bugs across all domains: application code, tests, data pipelines, ML models, and infrastructure. It covers debugging strategies, tool usage, and techniques for various types of issues including crashes, flaky tests, data quality problems, and model performance degradation.
+This skill provides systematic approaches to finding and fixing bugs across all domains: application code, tests, data pipelines, ML models, and infrastructure. It covers debugging strategies, tool usage, and techniques for crashes, flaky tests, data quality problems, and model performance degradation.
 
-## Instructions
+## Workflow
 
-### 1. Understand the Problem
+The agent follows these numbered steps when debugging any issue:
 
-- Reproduce the issue consistently
-- Gather error messages and stack traces
-- Identify when the bug was introduced
-- Determine the expected vs actual behavior
-
-### 2. Isolate the Issue
-
-- Create minimal reproduction case
-- Use binary search to narrow down cause
-- Check recent changes (git bisect)
-- Verify environment and dependencies
-
-### 3. Diagnose Root Cause
-
-- Add strategic logging
-- Use debugger to step through code
-- Analyze stack traces
-- Check for common patterns
-
-### 4. Fix and Verify
-
-- Implement targeted fix
-- Add regression test
-- Verify fix doesn't introduce new issues
-- Document the root cause
+1. **Understand the Problem** — Reproduce the issue consistently. Gather error messages and stack traces. Identify when the bug was introduced. Determine expected vs actual behavior.
+2. **Isolate the Issue** — Create a minimal reproduction case. Use binary search (git bisect) to narrow the cause. Check recent changes. Verify environment and dependencies.
+3. **Diagnose Root Cause** — Add strategic logging. Use a debugger to step through code. Analyze stack traces. Check for common patterns (off-by-one, race conditions, null references).
+4. **Fix and Verify** — Implement a targeted fix. Add a regression test. Verify the fix does not introduce new issues. Document the root cause.
 
 ## Best Practices
 
-1. **Reproduce First**: Never fix what you can't reproduce
-2. **Read Error Messages**: They often contain the answer
-3. **Check Recent Changes**: Most bugs are recently introduced
-4. **Question Assumptions**: Verify what you think you know
-5. **Isolate Variables**: Change one thing at a time
-6. **Use Source Control**: Git bisect is powerful
-7. **Write Tests**: Prove the bug exists, then prove it's fixed
+1. **Reproduce First**: The agent never attempts a fix without first reproducing the problem.
+2. **Read Error Messages**: They often contain the answer directly.
+3. **Check Recent Changes**: Most bugs are recently introduced — git log and git bisect are powerful.
+4. **Question Assumptions**: The agent verifies what it thinks it knows before acting.
+5. **Isolate Variables**: Change one thing at a time to confirm causality.
+6. **Write Tests**: Prove the bug exists with a failing test, then prove it is fixed.
 
 ## Specialized Debugging Domains
 
-### Debugging Flaky Tests
+### Flaky Tests
 
-Flaky tests pass/fail non-deterministically. Common root causes:
+Flaky tests pass and fail non-deterministically. The agent checks these root causes in order:
 
-**Timing Issues:**
+- **Timing issues** — Race conditions in async code, insufficient waits for UI elements, network timeouts, background jobs not completing.
+- **Non-deterministic state** — Random data without seeds, unordered collections, floating-point precision, timestamp-based logic.
+- **Test isolation failures** — Shared global state, database not cleaned between runs, file resources not cleaned up, test order dependencies.
 
-- Race conditions in async code
-- Insufficient wait times for UI elements
-- Network request timeouts
-- Background jobs not completing
-
-**Non-Deterministic State:**
-
-- Random data generation without seeds
-- Unordered collections (sets, map iteration)
-- Floating-point precision issues
-- Timestamp-based logic in tests
-
-**Test Isolation Failures:**
-
-- Shared global state between tests
-- Database not cleaned between runs
-- Files/resources not properly cleaned up
-- Test execution order dependencies
-
-**Debugging Techniques:**
+Debugging commands:
 
 ```bash
-# Run test multiple times to reproduce flakiness
+# Run test repeatedly to reproduce flakiness
 for i in {1..100}; do cargo test test_name || break; done
 
-# Run with verbose logging to expose timing
+# Force serial execution to check for shared state
+cargo test -- --test-threads=1
+
+# Verbose logging to expose timing
 RUST_LOG=debug cargo test test_name
-
-# Check for shared state issues
-cargo test -- --test-threads=1  # Force serial execution
-
-# Identify timing-dependent tests
-cargo test -- --nocapture | grep -i "timeout\|sleep\|wait"
 ```
 
-**Fixes:**
+Fixes include explicit waits instead of sleeps, seeded random generators, proper teardown in fixtures, and test isolation patterns (transactions, temp directories).
 
-- Add explicit waits instead of arbitrary sleeps
-- Seed random generators: `rand::thread_rng().seed(42)`
-- Clean up state in test fixtures/teardown
-- Use test isolation patterns (transactions, temp directories)
-- Mock time-dependent code
+### Data Pipelines
 
-### Debugging Data Pipelines
+Data pipeline bugs manifest as incorrect results, crashes on specific data, or performance issues. Common causes include schema mismatches between stages, null/missing value handling, data type conversions (precision loss, overflow), and encoding issues.
 
-Data pipeline bugs manifest as incorrect results, crashes on specific data, or performance issues.
+The agent validates data at pipeline stage boundaries, logs sample records at each transformation, and tests with edge cases (nulls, empty strings, extreme values).
 
-**Common Issues:**
+### ML Models
 
-- Schema mismatches between stages
-- Null/missing value handling
-- Data type conversions (precision loss, overflow)
-- Encoding issues (UTF-8, special characters)
-- Memory issues with large datasets
+ML debugging involves both code bugs and model behavior issues. The agent checks:
 
-**Debugging Techniques:**
+- **Training issues** — Loss not decreasing (learning rate), loss exploding (gradient issues), overfitting, underfitting.
+- **Inference issues** — Prediction distribution shift, performance degradation over time, train/inference inconsistency, memory leaks in serving.
 
-```python
-# Sample problematic data for local debugging
-df_sample = df.filter("problematic_condition").limit(1000)
-df_sample.write.parquet("debug_sample.parquet")
-
-# Add data quality assertions
-assert df.filter(col("user_id").isNull()).count() == 0, "Null user_ids found"
-assert df.filter(col("amount") < 0).count() == 0, "Negative amounts found"
-
-# Profile memory and performance
-df.explain()  # Show execution plan
-df.cache()    # Materialize for profiling
-
-# Check schema evolution issues
-df.printSchema()
-df.dtypes  # Verify expected types
-```
-
-**Root Cause Analysis:**
-
-- Check upstream data sources for schema changes
-- Validate data at pipeline stage boundaries
-- Log sample records at each transformation
-- Use data profiling tools to find anomalies
-- Test with edge cases: nulls, empty strings, extreme values
-
-### Debugging ML Models
-
-ML debugging involves both code bugs and model behavior issues.
-
-**Training Issues:**
-
-- Loss not decreasing (learning rate, gradient flow)
-- Loss exploding (gradient explosion, numerical instability)
-- Overfitting (model memorizes training data)
-- Underfitting (model too simple for data)
-
-**Inference Issues:**
-
-- Prediction distribution shift
-- Performance degradation over time
-- Inconsistent results between training/inference
-- Memory leaks in model serving
-
-**Debugging Techniques:**
-
-```python
-# Check gradient flow
-for name, param in model.named_parameters():
-    if param.grad is not None:
-        print(f"{name}: grad norm = {param.grad.norm()}")
-    else:
-        print(f"{name}: NO GRADIENT")  # Dead layer!
-
-# Detect numerical issues
-torch.autograd.set_detect_anomaly(True)  # Catch NaN/Inf
-
-# Validate data preprocessing
-print("Training data stats:", train_data.mean(), train_data.std())
-print("Inference data stats:", inference_data.mean(), inference_data.std())
-# If stats differ significantly, preprocessing mismatch!
-
-# Profile model performance
-import torch.autograd.profiler as profiler
-with profiler.profile(use_cuda=True) as prof:
-    model(input_data)
-print(prof.key_averages().table())
-
-# Test on single example
-model.eval()
-with torch.no_grad():
-    output = model(single_input)
-    print(f"Input: {single_input}, Output: {output}")
-```
-
-**Root Cause Analysis:**
-
-- Verify data preprocessing matches training
-- Check for label leakage or data contamination
-- Validate feature distributions (training vs production)
-- Test model on known examples with expected outputs
-- Use explainability tools (SHAP, attention weights)
+Root cause analysis includes verifying data preprocessing matches training, checking for label leakage, validating feature distributions between training and production, and using explainability tools (SHAP, attention weights).
 
 ## Examples
 
-### Example 1: Systematic Debugging Process
+### Example 1: Systematic Null-Check Debugging
 
 ```python
 # Step 1: Understand the error
-"""
-Error: TypeError: Cannot read property 'name' of undefined
-at processUser (src/users.py:45)
-at handleRequest (src/server.py:123)
-"""
+# Error: TypeError: Cannot read property 'name' of undefined
+# at processUser (src/users.py:45)
 
 # Step 2: Add diagnostic logging
 def process_user(user_id: str) -> dict:
     logger.debug(f"Processing user_id: {user_id}")
-
     user = get_user(user_id)
     logger.debug(f"Retrieved user: {user}")  # <-- User is None!
-
-    # Bug: No null check before accessing properties
     return {"name": user.name}  # Crashes here
 
 # Step 3: Fix with proper null handling
 def process_user(user_id: str) -> dict:
-    logger.debug(f"Processing user_id: {user_id}")
-
     user = get_user(user_id)
     if user is None:
         logger.warning(f"User not found: {user_id}")
         raise UserNotFoundError(f"User {user_id} not found")
-
     return {"name": user.name}
 
 # Step 4: Add regression test
@@ -249,17 +111,14 @@ git bisect bad
 # Mark known good commit (before bug existed)
 git bisect good v1.2.0
 
-# Git checks out middle commit, test it
-# Run your test
+# Git checks out a middle commit — run the test
 npm test
 
-# Mark result
+# Mark result and repeat
 git bisect good  # or git bisect bad
 
-# Repeat until git identifies the first bad commit
-# Git will output: "abc123 is the first bad commit"
-
-# View the problematic commit
+# Git identifies the first bad commit
+# Output: "abc123 is the first bad commit"
 git show abc123
 
 # End bisect session
@@ -270,184 +129,51 @@ git bisect reset
 
 ```python
 # Pattern 1: Off-by-one errors
-# Bug: Missing last element
-for i in range(len(items) - 1):  # Wrong!
+for i in range(len(items) - 1):  # Wrong — misses last element
     process(items[i])
-# Fix:
-for i in range(len(items)):
+for i in range(len(items)):      # Fixed
     process(items[i])
 
 # Pattern 2: Race conditions
-# Bug: Check-then-act without synchronization
 if not file.exists():
-    file.create()  # Another thread might create between check and create
-# Fix: Use atomic operations
-file.create_if_not_exists()
+    file.create()  # Another thread may create between check and create
+file.create_if_not_exists()  # Fixed — atomic operation
 
 # Pattern 3: Floating point comparison
-# Bug: Direct equality comparison
-if 0.1 + 0.2 == 0.3:  # This is False!
+if 0.1 + 0.2 == 0.3:          # False due to IEEE 754
     do_something()
-# Fix: Use approximate comparison
-if abs((0.1 + 0.2) - 0.3) < 1e-9:
+if abs((0.1 + 0.2) - 0.3) < 1e-9:  # Fixed — approximate comparison
     do_something()
 
 # Pattern 4: Mutable default arguments
-# Bug: Shared mutable default
-def add_item(item, items=[]):  # Same list instance reused!
+def add_item(item, items=[]):      # Bug — same list reused across calls
     items.append(item)
     return items
-# Fix: Use None default
-def add_item(item, items=None):
+def add_item(item, items=None):    # Fixed — None default
     if items is None:
         items = []
     items.append(item)
     return items
-
-# Pattern 5: Silent failures
-# Bug: Swallowing exceptions
-try:
-    risky_operation()
-except Exception:
-    pass  # Bug hidden!
-# Fix: Handle or re-raise appropriately
-try:
-    risky_operation()
-except SpecificException as e:
-    logger.error(f"Operation failed: {e}")
-    raise
 ```
 
-### Example 4: Debugging Tools Usage
-
-```bash
-# Python debugging
-python -m pdb script.py  # Interactive debugger
-python -m trace --trace script.py  # Trace execution
-
-# Node.js debugging
-node --inspect script.js  # Chrome DevTools
-node --inspect-brk script.js  # Break on first line
-
-# Rust debugging
-RUST_BACKTRACE=1 cargo run  # Full stack trace
-RUST_LOG=debug cargo run    # Verbose logging
-
-# Memory profiling (Python)
-python -m memory_profiler script.py
-
-# CPU profiling (Python)
-python -m cProfile -o output.prof script.py
-python -m pstats output.prof
-
-# Strace for system calls (Linux)
-strace -f -e trace=file python script.py
-
-# Network debugging
-tcpdump -i any port 8080
-curl -v http://localhost:8080/api/health
-```
-
-### Example 5: Debugging Flaky Test
+### Example 4: Debugging a Flaky Test
 
 ```python
-# Flaky test - fails intermittently
+# Flaky test — fails intermittently due to shared database state
 def test_user_registration():
     user = create_user(email="test@example.com")
-    # Sometimes fails: "User already exists"
-    assert user.id is not None
+    assert user.id is not None  # Sometimes: "User already exists"
 
-# Diagnosis: Test isolation failure - database not cleaned between runs
-
-# Fix: Add proper teardown
+# Fix: Add proper teardown for test isolation
 @pytest.fixture(autouse=True)
 def clean_database():
     yield
-    # Clean up after each test
     User.query.delete()
     db.session.commit()
-
-def test_user_registration():
-    user = create_user(email="test@example.com")
-    assert user.id is not None
 
 # Alternative fix: Use unique data per test run
 def test_user_registration():
     email = f"test-{uuid.uuid4()}@example.com"
     user = create_user(email=email)
     assert user.id is not None
-```
-
-### Example 6: Debugging Data Pipeline
-
-```python
-# Data pipeline crashes on production data but works on test data
-def transform_orders(df):
-    # Bug: Crashes when discount column has nulls
-    df["final_price"] = df["price"] * (1 - df["discount"])
-    return df
-
-# Diagnosis: Add assertions to catch bad data early
-def transform_orders(df):
-    # Check assumptions about input data
-    assert "price" in df.columns, "Missing price column"
-    assert "discount" in df.columns, "Missing discount column"
-
-    # Expose the bug
-    null_discounts = df[df["discount"].isnull()]
-    if len(null_discounts) > 0:
-        print(f"Found {len(null_discounts)} orders with null discounts")
-        print(null_discounts.head())
-
-    # Fix: Handle nulls explicitly
-    df["discount"] = df["discount"].fillna(0.0)
-    df["final_price"] = df["price"] * (1 - df["discount"])
-    return df
-
-# Add data validation test
-def test_transform_orders_handles_nulls():
-    df = pd.DataFrame({
-        "price": [100, 200],
-        "discount": [0.1, None]  # Null discount
-    })
-    result = transform_orders(df)
-    assert result["final_price"].tolist() == [90.0, 200.0]
-```
-
-### Example 7: Debugging ML Model Performance
-
-```python
-# Model accuracy dropped from 95% to 75% in production
-
-# Step 1: Compare training vs production data distributions
-train_stats = train_df.describe()
-prod_stats = production_df.describe()
-print("Feature drift detected:")
-for col in train_stats.columns:
-    train_mean = train_stats.loc["mean", col]
-    prod_mean = prod_stats.loc["mean", col]
-    drift = abs(prod_mean - train_mean) / train_mean
-    if drift > 0.1:
-        print(f"{col}: {drift*100:.1f}% drift")
-
-# Step 2: Test on individual examples to find pattern
-test_cases = [
-    {"input": [...], "expected": 1, "predicted": model.predict([...])},
-    {"input": [...], "expected": 0, "predicted": model.predict([...])},
-]
-for case in test_cases:
-    if case["expected"] != case["predicted"]:
-        print(f"Misprediction: {case}")
-
-# Step 3: Root cause - feature preprocessing changed
-# Training: features normalized with StandardScaler fit on training data
-# Production: features normalized with different scaler parameters!
-
-# Fix: Save and load scaler with model
-import joblib
-joblib.dump(scaler, "scaler.pkl")
-# In production:
-scaler = joblib.load("scaler.pkl")
-features_scaled = scaler.transform(features)
-predictions = model.predict(features_scaled)
 ```

--- a/skills/loom-docker/SKILL.md
+++ b/skills/loom-docker/SKILL.md
@@ -1,230 +1,89 @@
 ---
 name: loom-docker
-description: Creates and optimizes Docker configurations including Dockerfiles, docker-compose files, and container orchestration. Covers multi-stage builds, layer optimization, security hardening, networking, volumes, and debugging. Trigger keywords: docker, container, dockerfile, image, compose, registry, build, layer, cache, multi-stage, volume, network, port, environment, containerize, orchestration, registry, push, pull, tag, alpine, slim, distroless.
+description: "Creates and optimizes Docker configurations including Dockerfiles, docker-compose files, and container orchestration. Covers multi-stage builds, layer optimization, security hardening, networking, volumes, and debugging. Use when the user needs to containerize an application, optimize Docker images, configure docker-compose services, or troubleshoot container issues."
 allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+trigger-keywords: docker, container, dockerfile, image, compose, registry, build, layer, cache, multi-stage, volume, network, port, environment, containerize, orchestration, push, pull, tag, alpine, slim, distroless
 ---
 
 # Docker
 
 ## Overview
 
-This skill provides comprehensive Docker expertise for all container-related tasks. It covers:
-
-- **Strategy & Architecture**: Container strategy for applications, deployment patterns, orchestration decisions
-- **Implementation**: Writing optimized Dockerfiles, docker-compose files, and CI/CD integration
-- **Security**: Container hardening, vulnerability scanning, secrets management, runtime protection
-- **Operations**: Image optimization, layer caching, debugging, registry management, performance tuning
-
-Use this skill for anything related to containerization, from initial strategy through production deployment.
+This skill provides Docker expertise for all container-related tasks including writing optimized Dockerfiles, docker-compose files, security hardening, image optimization, and debugging. It covers the full lifecycle from initial containerization strategy through production deployment.
 
 ## Instructions
 
 ### 1. Analyze Application Requirements
 
-Before creating container configurations:
+Before creating container configurations, the agent should identify:
 
-- **Runtime Dependencies**: Identify language runtime, system libraries, native extensions
+- **Runtime Dependencies**: Language runtime, system libraries, native extensions
 - **Build vs Runtime Separation**: Plan multi-stage builds to separate build tools from runtime
-- **Configuration Management**: Plan environment variables, secrets, config files
-- **Data Persistence**: Identify stateful vs stateless components, volume mount points
-- **Network Requirements**: Document ports, service dependencies, external integrations
-- **Resource Constraints**: Consider memory, CPU, disk requirements
-- **Deployment Target**: Development, staging, production environments
+- **Configuration Management**: Environment variables, secrets, config files
+- **Data Persistence**: Stateful vs stateless components, volume mount points
+- **Network Requirements**: Ports, service dependencies, external integrations
+- **Deployment Target**: Development, staging, or production environments
 
 ### 2. Write Efficient Dockerfiles
 
 #### Base Image Selection
 
-- **Official Images**: Prefer official language/OS images from Docker Hub
-- **Minimal Images**: Use Alpine (-alpine), Slim (-slim), or Distroless for production
-- **Pin Versions**: Use specific tags (python:3.12-alpine) not latest
-- **Multi-Stage Pattern**: Separate builder and runtime stages
+- Prefer official language/OS images from Docker Hub
+- Use Alpine (-alpine), Slim (-slim), or Distroless for production
+- Pin specific version tags (e.g., `python:3.12-alpine`), never use `latest`
+- Use multi-stage builds to separate builder and runtime stages
 
 #### Layer Optimization
 
-- **Order Matters**: Place least-changing instructions first (base image, system deps)
-- **Combine Commands**: Use && to chain related RUN commands into single layers
-- **Clear Caches**: Clean package manager caches in same RUN command
-- **Copy Strategically**: Copy dependency files before source code for better caching
-
-#### Image Size Reduction
-
-- **Multi-Stage Builds**: Only copy artifacts needed at runtime
-- **Remove Build Tools**: Don't include compilers, dev headers in final image
-- **Minimize Layers**: Combine RUN commands where logical
-- **Use .dockerignore**: Exclude unnecessary files from build context
+- Place least-changing instructions first (base image, system deps)
+- Chain related RUN commands with `&&` to reduce layer count
+- Clean package manager caches in the same RUN command they are created
+- Copy dependency files before source code for better caching
+- Use `--mount=type=cache` for package manager caches with BuildKit
 
 #### Security Best Practices
 
-- **Non-Root User**: Create and switch to non-privileged user
-- **Read-Only Filesystems**: Use read-only root filesystem where possible
-- **No Secrets in Layers**: Use build secrets, not ENV or COPY for credentials
-- **Scan Images**: Run vulnerability scanners (trivy, grype) in CI
+- Create and switch to a non-root user
+- Use read-only root filesystem where possible
+- Use `--mount=type=secret` for build-time secrets; never embed secrets in ENV, ARG, or COPY
+- Scan images with vulnerability scanners (trivy, grype, Docker Scout) in CI
+- Drop unnecessary Linux capabilities; never use `--privileged` without justification
 
-### 3. Configure Docker Compose Files
+### 3. Configure Docker Compose
 
-#### Service Definition
+- Use `depends_on` with `condition: service_healthy` for service dependencies
+- Define HEALTHCHECK commands for critical services
+- Set appropriate restart policies (`unless-stopped`, `on-failure`)
+- Define named networks for service isolation; mark internal services without external ports
+- Use named volumes for data persistence; bind mounts for development only
+- Use `.env` files for local development; docker secrets or external managers for production
+- Use `${VAR:-default}` for variable interpolation with defaults
 
-- **Service Dependencies**: Use depends_on with conditions (service_healthy)
-- **Health Checks**: Define health check commands for critical services
-- **Restart Policies**: Set appropriate restart behavior (unless-stopped, on-failure)
-- **Resource Limits**: Define memory and CPU limits for production
+### 4. Language-Specific Patterns
 
-#### Networking
+- **Python**: Use `pip wheel` for cached compiled deps; `--no-cache-dir` to prevent pip cache in layers; `python:3.x-slim` for production
+- **Node.js**: Copy `package*.json` before source; use `npm ci` for reproducible builds; remove devDependencies in production
+- **Rust**: Use `cargo-chef` for dependency caching; build with `--release`; copy only the binary to a distroless runtime stage
+- **Go**: Build statically with `CGO_ENABLED=0`; use `scratch` or distroless for runtime; copy only the binary
 
-- **Custom Networks**: Define named networks for service isolation
-- **Internal Services**: Mark databases, caches as internal (no external ports)
-- **Service Discovery**: Use service names for DNS-based discovery
-- **Port Mapping**: Map only necessary ports to host
+### 5. Development vs Production
 
-#### Volumes and Persistence
+**Development**: bind mounts for live reload, include debugging tools, verbose logging, expose additional ports.
 
-- **Named Volumes**: Use named volumes for data persistence
-- **Bind Mounts**: Use for development (code changes) but not production data
-- **Volume Ownership**: Ensure correct user/group ownership in containers
-- **Backup Strategy**: Document volume backup procedures
-
-#### Environment Configuration
-
-- **Environment Files**: Use .env files for local development
-- **Secret Management**: Use docker secrets or external secret managers
-- **Environment Inheritance**: Use environment block for shared config
-- **Variable Interpolation**: Use ${VAR:-default} for defaults
-
-### 4. Container Security Hardening
-
-#### Runtime Security
-
-- **Minimal Base Images**: Reduce attack surface with distroless or alpine
-- **Drop Capabilities**: Remove unnecessary Linux capabilities
-- **Read-Only Root**: Mount root filesystem as read-only
-- **No Privileged Mode**: Never use --privileged unless absolutely necessary
-- **AppArmor/SELinux**: Use security profiles where available
-
-#### Vulnerability Management
-
-- **Regular Scanning**: Scan images with trivy, grype, or Docker Scout
-- **Dependency Updates**: Keep base images and dependencies current
-- **CVE Monitoring**: Track and remediate known vulnerabilities
-- **SBOM Generation**: Create software bill of materials for compliance
-
-#### Secrets Management
-
-- **Never in Dockerfile**: No secrets in ENV, ARG, or committed files
-- **Build Secrets**: Use --mount=type=secret for build-time secrets
-- **Runtime Secrets**: Use docker secrets, vault, or k8s secrets
-- **Environment Variables**: Only for non-sensitive configuration
-
-### 5. Image Optimization Techniques
-
-#### Multi-Stage Build Patterns
-
-- **Builder Stage**: Install build dependencies, compile code
-- **Runtime Stage**: Copy only artifacts, minimal dependencies
-- **Shared Stages**: Reuse common base stages across images
-- **Parallel Builds**: Use BuildKit for parallel stage execution
-
-#### Layer Caching Strategies
-
-- **Dependency Layers**: Copy package files before code for cache reuse
-- **Cache Mounts**: Use --mount=type=cache for package manager caches
-- **Ordered Instructions**: Structure Dockerfile for maximum cache hits
-- **Build Context**: Minimize context size with .dockerignore
-
-#### Registry Management
-
-- **Image Tagging**: Use semantic versioning and git SHA tags
-- **Multi-Architecture**: Build for amd64 and arm64 with buildx
-- **Registry Mirrors**: Use local registry mirrors for faster pulls
-- **Garbage Collection**: Clean old images from registry regularly
-
-### 6. Debugging Containers
-
-#### Interactive Debugging
-
-- **Shell Access**: docker exec -it `<container>` /bin/sh
-- **Debug Images**: Temporarily use non-minimal base for troubleshooting
-- **Ephemeral Containers**: Use debug sidecars in Kubernetes
-- **Log Inspection**: docker logs -f --tail 100 `<container>`
-
-#### Common Issues
-
-- **Permission Errors**: Check user/group IDs match volume ownership
-- **Network Issues**: Verify network configuration, DNS resolution
-- **Missing Dependencies**: Check runtime dependencies in final stage
-- **Build Failures**: Use --progress=plain for detailed build output
-- **Layer Size**: Use dive tool to analyze layer sizes
-
-#### Tools and Techniques
-
-- **Dive**: Analyze image layers and find bloat
-- **Hadolint**: Lint Dockerfiles for best practices
-- **Docker Scout**: Scan for vulnerabilities and recommendations
-- **Trivy**: Comprehensive vulnerability scanning
-- **Ctop**: Container resource monitoring
+**Production**: named volumes for persistence, minimal images with only runtime deps, restricted ports and capabilities, structured logging to stdout/stderr, no SSH or debugging tools in final image.
 
 ## Best Practices
 
-### Universal Principles
-
-1. **Use Official Base Images**: Start from trusted sources (Docker Official Images)
-2. **Multi-Stage Builds**: Separate build and runtime environments to minimize size
-3. **Minimize Layers**: Combine related commands with && to reduce layer count
-4. **Don't Run as Root**: Create and use non-root users for security
-5. **Use .dockerignore**: Exclude unnecessary files from build context
-6. **Pin Versions**: Use specific tags (python:3.12-alpine) not latest
-7. **Health Checks**: Add HEALTHCHECK instructions for container health monitoring
-8. **Scan Regularly**: Run vulnerability scanners in CI/CD pipeline
-9. **Clear Caches**: Remove package manager caches in same layer they're created
-10. **Document Thoroughly**: Add comments explaining non-obvious decisions
-
-### Language-Specific Patterns
-
-#### Python
-
-- Use pip wheel to cache compiled dependencies
-- Use --no-cache-dir to prevent pip cache in layers
-- Consider uv for faster dependency resolution
-- Use python:3.x-slim for balance of size and compatibility
-
-#### Node.js
-
-- Copy package\*.json before source for better caching
-- Use npm ci instead of npm install for reproducible builds
-- Remove devDependencies in production builds
-- Consider node:alpine for minimal size
-
-#### Rust
-
-- Use cargo chef for dependency caching
-- Build with --release for optimized binaries
-- Copy only the binary to runtime stage, not entire target/
-- Consider scratch or distroless base for minimal size
-
-#### Go
-
-- Use multi-stage with golang:alpine for build
-- Build statically linked binaries (CGO_ENABLED=0)
-- Use scratch or distroless for minimal runtime
-- COPY only the binary, Go doesn't need runtime
-
-### Development vs Production
-
-#### Development
-
-- Use bind mounts for live code reloading
-- Include debugging tools in image
-- Expose more ports for inspection
-- Use verbose logging
-- Mount source code as volume
-
-#### Production
-
-- Use named volumes for persistence
-- Minimal images with only runtime dependencies
-- Restricted ports and capabilities
-- Structured logging to stdout/stderr
-- No SSH, debugging tools, or shells in final image
+1. **Use Official Base Images** from trusted sources
+2. **Multi-Stage Builds** to separate build and runtime environments
+3. **Minimize Layers** by combining related commands with `&&`
+4. **Run as Non-Root** user for security
+5. **Use .dockerignore** to exclude unnecessary files from build context
+6. **Pin Versions** on base images and dependencies
+7. **Add HEALTHCHECK** instructions for container health monitoring
+8. **Scan Regularly** with vulnerability scanners
+9. **Clear Caches** in the same layer they are created
+10. **Document Non-Obvious Decisions** with comments in Dockerfiles
 
 ## Examples
 
@@ -233,91 +92,55 @@ Before creating container configurations:
 ```dockerfile
 # Build stage
 FROM python:3.12-slim AS builder
-
 WORKDIR /app
-
-# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
-
-# Install Python dependencies
 COPY requirements.txt .
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
 
 # Runtime stage
 FROM python:3.12-slim AS runtime
-
-# Create non-root user
 RUN groupadd --gid 1000 appgroup && \
     useradd --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
-
 WORKDIR /app
-
-# Copy wheels from builder
 COPY --from=builder /app/wheels /wheels
 RUN pip install --no-cache-dir /wheels/* && rm -rf /wheels
-
-# Copy application code
 COPY --chown=appuser:appgroup . .
-
-# Switch to non-root user
 USER appuser
-
-# Expose port
 EXPOSE 8000
-
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
-
-# Run application
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "app:create_app()"]
 ```
 
-### Example 2: Node.js Dockerfile with Security
+### Example 2: Rust Dockerfile with Cargo Chef
 
 ```dockerfile
-FROM node:20-alpine AS builder
-
+# Chef stage - plan dependencies
+FROM rust:1.75-alpine AS chef
+RUN apk add --no-cache musl-dev && cargo install cargo-chef
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Planner stage - analyze dependencies
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo chef prepare --recipe-path recipe.json
 
-# Install dependencies
-RUN npm ci --only=production
-
-# Copy source code
+# Builder stage - build dependencies then app
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
+RUN cargo build --release && strip target/release/myapp
 
-# Build application
-RUN npm run build
-
-# Production stage
-FROM node:20-alpine AS production
-
-# Add security updates
-RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
-
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nextjs -u 1001
-
-WORKDIR /app
-
-# Copy built assets
-COPY --from=builder --chown=nextjs:nodejs /app/dist ./dist
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
-COPY --from=builder --chown=nextjs:nodejs /app/package.json ./
-
-USER nextjs
-
-EXPOSE 3000
-
-ENV NODE_ENV=production
-
-CMD ["node", "dist/server.js"]
+# Runtime stage - minimal distroless image
+FROM gcr.io/distroless/cc-debian12
+COPY --from=builder /app/target/release/myapp /usr/local/bin/myapp
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/myapp"]
 ```
 
 ### Example 3: Docker Compose for Development
@@ -351,7 +174,6 @@ services:
     image: postgres:16-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass
@@ -372,19 +194,6 @@ services:
     networks:
       - app-network
 
-  nginx:
-    image: nginx:alpine
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./certs:/etc/nginx/certs:ro
-    depends_on:
-      - app
-    networks:
-      - app-network
-
 volumes:
   postgres_data:
   redis_data:
@@ -394,673 +203,60 @@ networks:
     driver: bridge
 ```
 
-### Example 4: Rust Dockerfile with Cargo Chef
-
-```dockerfile
-# Chef stage - plan dependencies
-FROM rust:1.75-alpine AS chef
-RUN apk add --no-cache musl-dev && \
-    cargo install cargo-chef
-WORKDIR /app
-
-# Planner stage - analyze dependencies
-FROM chef AS planner
-COPY Cargo.toml Cargo.lock ./
-COPY src ./src
-RUN cargo chef prepare --recipe-path recipe.json
-
-# Builder stage - build dependencies then app
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-
-# Build dependencies (cached layer)
-RUN cargo chef cook --release --recipe-path recipe.json
-
-# Copy source and build application
-COPY . .
-RUN cargo build --release && \
-    strip target/release/myapp
-
-# Runtime stage - minimal distroless image
-FROM gcr.io/distroless/cc-debian12
-
-# Copy only the binary
-COPY --from=builder /app/target/release/myapp /usr/local/bin/myapp
-
-# Run as non-root (distroless provides nonroot user)
-USER nonroot:nonroot
-
-EXPOSE 8080
-
-ENTRYPOINT ["/usr/local/bin/myapp"]
-```
-
-### Example 5: Go Dockerfile with Static Binary
-
-```dockerfile
-# Builder stage
-FROM golang:1.22-alpine AS builder
-
-WORKDIR /app
-
-# Install build dependencies
-RUN apk add --no-cache git ca-certificates tzdata
-
-# Copy go mod files for caching
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy source code
-COPY . .
-
-# Build static binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags='-w -s -extldflags "-static"' \
-    -o /app/bin/server ./cmd/server
-
-# Runtime stage - scratch (empty base)
-FROM scratch
-
-# Copy CA certificates for HTTPS
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Copy timezone data
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-
-# Copy binary
-COPY --from=builder /app/bin/server /server
-
-# Expose port
-EXPOSE 8080
-
-# Run as non-root (must be defined)
-USER 65534:65534
-
-ENTRYPOINT ["/server"]
-```
-
-### Example 6: Docker Compose with Secrets
-
-```yaml
-version: "3.8"
-
-services:
-  app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        - APP_VERSION=${APP_VERSION:-latest}
-    image: myapp:${APP_VERSION:-latest}
-    ports:
-      - "8080:8080"
-    environment:
-      - DATABASE_URL_FILE=/run/secrets/db_url
-      - API_KEY_FILE=/run/secrets/api_key
-    secrets:
-      - db_url
-      - api_key
-    depends_on:
-      db:
-        condition: service_healthy
-    networks:
-      - backend
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 512M
-        reservations:
-          cpus: "0.5"
-          memory: 256M
-
-  db:
-    image: postgres:16-alpine
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
-      POSTGRES_USER: myapp
-      POSTGRES_DB: myapp
-    secrets:
-      - db_password
-    networks:
-      - backend
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U myapp"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    restart: unless-stopped
-
-secrets:
-  db_url:
-    file: ./secrets/db_url.txt
-  api_key:
-    file: ./secrets/api_key.txt
-  db_password:
-    file: ./secrets/db_password.txt
-
-volumes:
-  postgres_data:
-
-networks:
-  backend:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.28.0.0/16
-```
-
-### Example 7: Build Cache Optimization with BuildKit
-
-```dockerfile
-# syntax=docker/dockerfile:1.4
-
-FROM node:20-alpine AS base
-
-# Enable BuildKit cache mounts
-WORKDIR /app
-
-# Install dependencies with cache mount
-FROM base AS deps
-COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci --only=production
-
-# Build stage with separate dev dependencies
-FROM base AS builder
-COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm \
-    npm ci
-COPY . .
-RUN npm run build
-
-# Production stage
-FROM base AS production
-
-# Copy production node_modules
-COPY --from=deps /app/node_modules ./node_modules
-
-# Copy built application
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package.json ./
-
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nextjs -u 1001
-
-USER nextjs
-
-EXPOSE 3000
-
-CMD ["node", "dist/index.js"]
-```
-
-### Example 8: .dockerignore
+### Example 4: .dockerignore
 
 ```gitignore
-# Git
 .git
 .gitignore
-
-# Dependencies
 node_modules
 __pycache__
 *.pyc
 .venv
-venv
-
-# Build artifacts
 dist
 build
-*.egg-info
-
-# IDE
 .idea
 .vscode
-*.swp
-
-# Testing
 coverage
 .pytest_cache
-.nyc_output
-
-# Environment files
 .env
 .env.local
 .env.*.local
-
-# Documentation
-docs
-*.md
-!README.md
-
-# Docker
 Dockerfile*
 docker-compose*
-.docker
-
-# Misc
+*.md
+!README.md
 .DS_Store
 *.log
 tmp
 ```
 
-## Common Patterns and Solutions
+## Troubleshooting
 
-### Pattern: Handling Configuration
+### Build Context Too Large
 
-#### Environment-based Config
+Add a comprehensive `.dockerignore`. Check for large files accidentally included (node_modules, .git, build artifacts). Build from a subdirectory if needed: `docker build -f Dockerfile.app ./app`.
 
-```dockerfile
-# Support multiple environments
-FROM node:20-alpine
+### Layer Caching Not Working
 
-WORKDIR /app
+Ensure dependency files are copied before source code. Avoid wildcard COPY at the start. Check for commands with dynamic output (dates, random values). Use BuildKit cache mounts for package managers.
 
-COPY package*.json ./
-RUN npm ci --only=production
+### Image Size Too Large
 
-COPY . .
+Use multi-stage builds. Choose smaller base images (alpine, slim, distroless). Clean caches in the same RUN command: `apt-get install ... && rm -rf /var/lib/apt/lists/*`. Use `dive` to analyze layer contents.
 
-# Default to production, can override at runtime
-ENV NODE_ENV=production
+### Permission Denied in Container
 
-# Use config files per environment
-CMD ["sh", "-c", "node server.js --config /app/config/${NODE_ENV}.json"]
-```
+Check volume ownership matches container user. Use `--chown=user:group` in COPY instructions. Create user with specific UID/GID matching host. Initialize volumes with correct ownership in entrypoint.
 
-#### Config from Files (12-Factor)
+### Container Cannot Connect to Other Services
 
-```dockerfile
-# Read config from files mounted at runtime
-FROM python:3.12-slim
+Verify services are on the same Docker network. Use service names for DNS, not localhost. Ensure the service listens on `0.0.0.0`, not `127.0.0.1`. Check `depends_on` and EXPOSE in Dockerfile.
 
-WORKDIR /app
+### Container Exits Immediately
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+Check logs with `docker logs <container>`. Run interactively: `docker run -it myapp /bin/sh`. Verify CMD/ENTRYPOINT is correct and executable. Check for missing environment variables or shared libraries.
 
-COPY . .
-
-# Application reads from /config at runtime
-VOLUME /config
-
-CMD ["python", "app.py", "--config", "/config/settings.yaml"]
-```
-
-### Pattern: Multi-Architecture Builds
-
-```bash
-# Build for multiple architectures with buildx
-docker buildx create --name multiarch --use
-docker buildx build --platform linux/amd64,linux/arm64 \
-  -t myapp:latest \
-  --push \
-  .
-```
-
-```dockerfile
-# Handle architecture differences in Dockerfile
-FROM --platform=${BUILDPLATFORM} golang:1.22-alpine AS builder
-
-ARG TARGETARCH
-ARG TARGETOS
-
-WORKDIR /app
-COPY . .
-
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -o /app/bin/server ./cmd/server
-
-FROM alpine:latest
-COPY --from=builder /app/bin/server /server
-ENTRYPOINT ["/server"]
-```
-
-### Pattern: Database Migrations
-
-```yaml
-# docker-compose with migration service
-version: "3.8"
-
-services:
-  migrate:
-    image: myapp:latest
-    command: ["./migrate", "up"]
-    environment:
-      DATABASE_URL: postgres://user:pass@db:5432/myapp
-    depends_on:
-      db:
-        condition: service_healthy
-    networks:
-      - backend
-
-  app:
-    image: myapp:latest
-    depends_on:
-      migrate:
-        condition: service_completed_successfully
-    environment:
-      DATABASE_URL: postgres://user:pass@db:5432/myapp
-    ports:
-      - "8080:8080"
-    networks:
-      - backend
-
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: pass
-      POSTGRES_DB: myapp
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U user -d myapp"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    networks:
-      - backend
-
-volumes:
-  db_data:
-
-networks:
-  backend:
-```
-
-### Pattern: Build-time Secrets
-
-```dockerfile
-# syntax=docker/dockerfile:1.4
-
-FROM node:20-alpine AS builder
-
-WORKDIR /app
-
-# Use secret at build time without leaving it in layers
-RUN --mount=type=secret,id=npmrc,target=/root/.npmrc \
-    npm ci
-
-COPY . .
-RUN npm run build
-
-FROM node:20-alpine AS production
-WORKDIR /app
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
-CMD ["node", "dist/server.js"]
-```
-
-```bash
-# Build with secret
-docker build --secret id=npmrc,src=$HOME/.npmrc -t myapp .
-```
-
-### Pattern: Health Check with Dependencies
-
-```dockerfile
-FROM python:3.12-slim
-
-# Install health check tool
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
-WORKDIR /app
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-# Comprehensive health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8000/health && \
-        python -c "import redis; redis.Redis(host='cache').ping()" || exit 1
-
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "app:app"]
-```
-
-## Troubleshooting Guide
-
-### Issue: Build Context Too Large
-
-**Symptoms**: Slow builds, "sending build context" takes minutes
-
-**Solutions**:
-
-1. Add comprehensive .dockerignore file
-2. Check for large files accidentally included (node_modules, .git, build artifacts)
-3. Use .dockerignore patterns like `**/.git` to exclude nested git repos
-4. Build from subdirectory: `docker build -f Dockerfile.app ./app`
-
-### Issue: Layer Caching Not Working
-
-**Symptoms**: Rebuilds everything despite no changes
-
-**Solutions**:
-
-1. Ensure dependency files are copied before source code
-2. Don't use wildcard COPY at the start of Dockerfile
-3. Check if commands have dynamic output (dates, random values)
-4. Use BuildKit cache mounts for package managers
-5. Verify build context hasn't changed (check .dockerignore)
-
-### Issue: Image Size Too Large
-
-**Symptoms**: Image is hundreds of MB when it should be small
-
-**Solutions**:
-
-1. Use multi-stage builds to exclude build dependencies
-2. Choose smaller base images (alpine, slim, distroless)
-3. Clean package manager caches in same RUN command: `apt-get install ... && rm -rf /var/lib/apt/lists/*`
-4. Remove unnecessary files before COPY to runtime stage
-5. Use `docker image history myapp:latest` to find large layers
-6. Use `dive` tool to analyze layer contents
-
-### Issue: Permission Denied in Container
-
-**Symptoms**: Cannot write files, "permission denied" errors
-
-**Solutions**:
-
-1. Check volume ownership matches container user
-2. Use `--chown=user:group` in COPY instructions
-3. Create user with specific UID/GID matching host: `useradd -u 1000`
-4. Initialize volumes with correct ownership in entrypoint
-5. For bind mounts, ensure host directory permissions are correct
-
-### Issue: Container Cannot Connect to Other Services
-
-**Symptoms**: "connection refused", "name not found" errors
-
-**Solutions**:
-
-1. Verify services are on same Docker network
-2. Use service names for DNS (not localhost)
-3. Check `depends_on` in docker-compose
-4. Ensure ports are exposed (EXPOSE in Dockerfile)
-5. Check if service is actually listening on correct interface (0.0.0.0 not 127.0.0.1)
-6. Verify firewall rules on host
-
-### Issue: Changes Not Reflected in Container
-
-**Symptoms**: Code changes don't appear, old version running
-
-**Solutions**:
-
-1. Check if using volume mounts for development
-2. Rebuild image if not using bind mounts: `docker-compose build`
-3. Remove containers and recreate: `docker-compose up --force-recreate`
-4. Clear build cache if needed: `docker builder prune`
-5. Verify correct image is running: `docker ps` and check IMAGE column
-
-### Issue: Container Exits Immediately
-
-**Symptoms**: Container starts then exits, no error message
-
-**Solutions**:
-
-1. Check logs: `docker logs <container>`
-2. Run interactively: `docker run -it myapp /bin/sh`
-3. Verify CMD/ENTRYPOINT is correct and executable
-4. Check if application requires environment variables
-5. Ensure dependencies are available (missing shared libraries)
-6. Add `tail -f /dev/null` temporarily to keep container running for debugging
-
-### Issue: Build Fails with "No Space Left on Device"
-
-**Symptoms**: Build fails midway with disk space error
-
-**Solutions**:
-
-1. Clean unused containers: `docker container prune`
-2. Remove unused images: `docker image prune -a`
-3. Clean build cache: `docker builder prune`
-4. Remove unused volumes: `docker volume prune`
-5. Check Docker disk usage: `docker system df`
-6. Increase Docker Desktop disk limit in settings
-
-### Issue: Slow Container Startup
-
-**Symptoms**: Container takes long time to become healthy
-
-**Solutions**:
-
-1. Optimize application startup (lazy loading, parallel initialization)
-2. Use smaller base images to reduce initial I/O
-3. Implement health check with appropriate start period
-4. Reduce number of layers to speed up image pull
-5. Use local registry or registry mirror to cache images
-6. Pre-pull images: `docker-compose pull`
-
-## CI/CD Integration
-
-### GitHub Actions Example
-
-```yaml
-name: Build and Push Docker Image
-
-on:
-  push:
-    branches: [main]
-    tags: ["v*"]
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ steps.meta.outputs.tags }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-
-      - name: Upload scan results
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: "trivy-results.sarif"
-```
-
-### GitLab CI Example
-
-```yaml
-stages:
-  - build
-  - test
-  - push
-
-variables:
-  DOCKER_DRIVER: overlay2
-  DOCKER_TLS_CERTDIR: "/certs"
-  IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA
-
-build:
-  stage: build
-  image: docker:24-cli
-  services:
-    - docker:24-dind
-  before_script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-  script:
-    - docker build --pull -t $IMAGE_TAG .
-    - docker push $IMAGE_TAG
-  only:
-    - main
-    - tags
-
-security-scan:
-  stage: test
-  image: aquasec/trivy:latest
-  script:
-    - trivy image --exit-code 1 --severity HIGH,CRITICAL $IMAGE_TAG
-  needs:
-    - build
-
-push-latest:
-  stage: push
-  image: docker:24-cli
-  services:
-    - docker:24-dind
-  before_script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-  script:
-    - docker pull $IMAGE_TAG
-    - docker tag $IMAGE_TAG $CI_REGISTRY_IMAGE:latest
-    - docker push $CI_REGISTRY_IMAGE:latest
-  only:
-    - main
-  needs:
-    - security-scan
-```
-
-## Quick Reference
-
-### Essential Commands
+## Quick Reference Commands
 
 ```bash
 # Build
@@ -1078,53 +274,16 @@ docker-compose up -d
 docker-compose down -v
 docker-compose logs -f app
 docker-compose exec app /bin/sh
-docker-compose build --no-cache
 
-# Inspect
+# Inspect and Debug
 docker ps
 docker logs -f <container>
-docker inspect <container>
 docker exec -it <container> /bin/sh
 docker stats
+docker run --rm -it --entrypoint /bin/sh myapp:latest
 
 # Clean
 docker system prune -a
 docker volume prune
 docker builder prune
-docker image prune -a
-
-# Debug
-docker run --rm -it --entrypoint /bin/sh myapp:latest
-docker cp <container>:/app/logfile.log ./local-logfile.log
-docker diff <container>
 ```
-
-### Performance Optimization Checklist
-
-- [ ] Using multi-stage builds
-- [ ] Minimal base image (alpine, slim, distroless)
-- [ ] Dependencies copied before source code
-- [ ] Package manager caches cleared in same layer
-- [ ] .dockerignore excludes unnecessary files
-- [ ] Build cache mounts for package managers
-- [ ] Layer count minimized (combined RUN commands)
-- [ ] Health checks defined
-- [ ] Non-root user configured
-- [ ] Specific version tags (not latest)
-- [ ] Security scanning in CI/CD
-- [ ] Image size < 200MB (adjust per use case)
-
-### Security Checklist
-
-- [ ] Using official/trusted base images
-- [ ] Base images pinned to specific versions
-- [ ] No secrets in Dockerfile or environment variables
-- [ ] Running as non-root user
-- [ ] Read-only root filesystem where possible
-- [ ] Minimal packages installed
-- [ ] Security updates applied
-- [ ] Vulnerability scanning enabled
-- [ ] No unnecessary capabilities
-- [ ] AppArmor/SELinux profiles applied
-- [ ] Secrets managed via Docker secrets or external vault
-- [ ] HTTPS certificates validated

--- a/skills/loom-rust/SKILL.md
+++ b/skills/loom-rust/SKILL.md
@@ -1,112 +1,74 @@
 ---
 name: loom-rust
-description: Rust language expertise for writing safe, performant, production-quality Rust code. Primary language for the Loom project. Use for Rust development, ownership patterns, error handling, async/await, cargo management, CLI tools, and serialization. Triggers: rust, cargo, rustc, ownership, borrowing, lifetime, trait, impl, struct, enum, Result, Option, async, await, tokio, serde, clap, thiserror, anyhow, Arc, Mutex, RwLock, RefCell, Box, Rc, Vec, HashMap, HashSet, String, derive, macro.
+description: "Rust language expertise for writing safe, performant, production-quality Rust code in the Loom project. Use when working with Rust development, ownership and borrowing patterns, error handling, async/await with tokio, cargo workspace management, CLI tools with clap, and serialization with serde. Rust is the primary language for Loom."
+allowed-tools: Read, Grep, Glob, Edit, Write, Bash
+trigger-keywords: rust, cargo, rustc, ownership, borrowing, lifetime, trait, impl, struct, enum, Result, Option, async, await, tokio, serde, clap, thiserror, anyhow, Arc, Mutex, RwLock, RefCell, Box, Rc, Vec, HashMap, derive, macro
 ---
 
 # Rust Language Expertise
 
 ## Overview
 
-This skill provides guidance for writing safe, efficient, and idiomatic Rust code. As the primary language for the Loom project, this skill covers:
+This skill provides guidance for writing safe, efficient, and idiomatic Rust code. As the primary language for the Loom project, it covers ownership and borrowing, error handling, traits and generics, async programming with tokio, CLI development with clap, serialization with serde, testing strategies, and cargo workspace management.
 
-- Ownership, borrowing, and lifetimes
-- Error handling with Result, Option, thiserror, and anyhow
-- Traits, generics, and type system patterns
-- Async programming with tokio runtime
-- CLI development with clap
-- Serialization with serde (JSON, TOML, YAML)
-- Common patterns and anti-patterns
-- Testing strategies
-- Cargo and workspace management
+## Ownership, Borrowing, and Lifetimes
 
-## Key Concepts
+The agent should follow these ownership rules when writing or reviewing Rust code:
 
-### Ownership, Borrowing, and Lifetimes
+1. Each value has exactly one owner.
+2. When the owner goes out of scope, the value is dropped.
+3. Ownership can be transferred (moved) or borrowed via references.
+
+### Borrowing and References
+
+- Immutable borrows (`&T`) allow read-only access; multiple simultaneous borrows are permitted.
+- Mutable borrows (`&mut T`) allow read-write access; only one mutable borrow at a time.
+- The agent should prefer borrowing over cloning to avoid unnecessary allocations.
+
+### Lifetimes
+
+- Lifetime annotations (`'a`) ensure references remain valid for their usage scope.
+- The agent should rely on lifetime elision where the compiler infers lifetimes automatically.
+- Explicit annotations are needed when a function returns a reference derived from multiple inputs.
 
 ```rust
-// Ownership rules:
-// 1. Each value has exactly one owner
-// 2. When the owner goes out of scope, the value is dropped
-// 3. Ownership can be transferred (moved) or borrowed
-
-// Move semantics
-fn take_ownership(s: String) {
-    println!("{}", s);
-} // s is dropped here
-
-fn main() {
-    let s = String::from("hello");
-    take_ownership(s);
-    // s is no longer valid here
-}
-
-// Borrowing (references)
-fn borrow(s: &String) {
-    println!("{}", s);
-}
-
-fn borrow_mut(s: &mut String) {
-    s.push_str(" world");
-}
-
-// Lifetimes ensure references are valid
+// Lifetime annotation example
 fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
     if x.len() > y.len() { x } else { y }
 }
 
-// Struct with lifetime annotations
+// Struct with lifetime
 struct Parser<'a> {
     input: &'a str,
     position: usize,
 }
-
-impl<'a> Parser<'a> {
-    fn new(input: &'a str) -> Self {
-        Parser { input, position: 0 }
-    }
-
-    fn peek(&self) -> Option<char> {
-        self.input[self.position..].chars().next()
-    }
-}
-
-// Common lifetime elision patterns
-impl Config {
-    // fn get(&self, key: &str) -> Option<&str>
-    // is short for:
-    // fn get<'a, 'b>(&'a self, key: &'b str) -> Option<&'a str>
-    fn get(&self, key: &str) -> Option<&str> {
-        self.map.get(key).map(|s| s.as_str())
-    }
-}
 ```
 
-### Error Handling
+## Error Handling
+
+The agent should use `thiserror` for library error types and `anyhow` for application-level code.
+
+### Library Errors with thiserror
 
 ```rust
-use std::error::Error;
-use std::fmt;
-use std::io;
-
-// Using thiserror for custom errors
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AppError {
     #[error("IO error: {0}")]
-    Io(#[from] io::Error),
+    Io(#[from] std::io::Error),
 
     #[error("Parse error at line {line}: {message}")]
     Parse { line: usize, message: String },
 
     #[error("Not found: {0}")]
     NotFound(String),
-
-    #[error("Validation failed: {0}")]
-    Validation(String),
 }
+```
 
-// Using anyhow for application code
+### Application Errors with anyhow
+
+```rust
 use anyhow::{Context, Result, bail, ensure};
 
 fn read_config(path: &str) -> Result<Config> {
@@ -124,630 +86,69 @@ fn read_config(path: &str) -> Result<Config> {
 
     Ok(config)
 }
-
-// The ? operator for propagating errors
-fn process_file(path: &str) -> Result<Vec<Record>, AppError> {
-    let content = std::fs::read_to_string(path)?; // io::Error -> AppError via From
-    let records = parse_records(&content)?;
-    Ok(records)
-}
-
-// Option handling
-fn find_user(users: &[User], name: &str) -> Option<&User> {
-    users.iter().find(|u| u.name == name)
-}
-
-fn get_user_email(users: &[User], name: &str) -> Option<String> {
-    users
-        .iter()
-        .find(|u| u.name == name)
-        .and_then(|u| u.email.clone())
-}
-
-// Converting between Option and Result
-fn require_user(users: &[User], name: &str) -> Result<&User, AppError> {
-    users
-        .iter()
-        .find(|u| u.name == name)
-        .ok_or_else(|| AppError::NotFound(format!("User: {}", name)))
-}
 ```
 
-### Traits and Generics
+### Option and Result Patterns
+
+- Use the `?` operator to propagate errors up the call stack.
+- Convert `Option` to `Result` with `.ok_or_else()` for meaningful error messages.
+- Use `.with_context()` from anyhow to add contextual information to errors.
+- Collect results with `.collect::<Result<Vec<_>>>()` to fail on the first error.
+
+## Traits and Generics
+
+The agent should define traits to express shared behavior and use generics with trait bounds for type-safe abstractions.
 
 ```rust
-// Defining traits
+// Trait definition with default method
 trait Repository<T> {
     fn get(&self, id: &str) -> Option<&T>;
-    fn save(&mut self, item: T) -> Result<(), Box<dyn Error>>;
+    fn save(&mut self, item: T) -> Result<(), Box<dyn std::error::Error>>;
 
-    // Default implementation
     fn exists(&self, id: &str) -> bool {
         self.get(id).is_some()
     }
 }
 
-// Trait bounds
-fn process<T: Clone + Debug>(item: &T) {
-    let cloned = item.clone();
-    println!("{:?}", cloned);
-}
-
-// where clauses for complex bounds
+// Where clauses for complex bounds
 fn merge<T, U, V>(a: T, b: U) -> V
 where
     T: IntoIterator<Item = V>,
     U: IntoIterator<Item = V>,
     V: Ord + Clone,
 {
-    let mut result: Vec<V> = a.into_iter().chain(b.into_iter()).collect();
-    result.sort();
-    result.dedup();
-    result.into_iter().next().unwrap()
-}
-
-// Associated types
-trait Iterator {
-    type Item;
-    fn next(&mut self) -> Option<Self::Item>;
-}
-
-// Implementing traits
-struct InMemoryRepo<T> {
-    items: HashMap<String, T>,
-}
-
-impl<T: Clone> Repository<T> for InMemoryRepo<T> {
-    fn get(&self, id: &str) -> Option<&T> {
-        self.items.get(id)
-    }
-
-    fn save(&mut self, item: T) -> Result<(), Box<dyn Error>> {
-        // Implementation
-        Ok(())
-    }
-}
-
-// Blanket implementations
-impl<T: Display> ToString for T {
-    fn to_string(&self) -> String {
-        format!("{}", self)
-    }
+    // implementation
 }
 ```
 
-### Iterators
+### Key Trait Patterns
+
+- **Associated types** over generic parameters when a trait has one natural type per implementation.
+- **Blanket implementations** (`impl<T: Display> ToString for T`) to extend behavior generically.
+- **Trait objects** (`Box<dyn Trait>`) for dynamic dispatch when concrete types are unknown at compile time.
+
+## Iterators
+
+The agent should prefer iterator chains over manual loops for clarity and performance.
 
 ```rust
-// Iterator combinators
 fn process_users(users: Vec<User>) -> Vec<String> {
     users
         .into_iter()
         .filter(|u| u.active)
         .map(|u| u.email)
-        .filter_map(|email| email)  // Remove None values
+        .filter_map(|email| email)
         .collect()
 }
-
-// Custom iterator
-struct Counter {
-    current: usize,
-    max: usize,
-}
-
-impl Iterator for Counter {
-    type Item = usize;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current < self.max {
-            let val = self.current;
-            self.current += 1;
-            Some(val)
-        } else {
-            None
-        }
-    }
-}
-
-// Useful iterator methods
-fn examples(numbers: Vec<i32>) {
-    // Fold/reduce
-    let sum: i32 = numbers.iter().fold(0, |acc, x| acc + x);
-
-    // Any/all
-    let has_positive = numbers.iter().any(|&x| x > 0);
-    let all_positive = numbers.iter().all(|&x| x > 0);
-
-    // Find
-    let first_even = numbers.iter().find(|&&x| x % 2 == 0);
-
-    // Partition
-    let (evens, odds): (Vec<_>, Vec<_>) = numbers.iter().partition(|&&x| x % 2 == 0);
-
-    // Enumerate
-    for (index, value) in numbers.iter().enumerate() {
-        println!("{}: {}", index, value);
-    }
-
-    // Zip
-    let other = vec![1, 2, 3];
-    let pairs: Vec<_> = numbers.iter().zip(other.iter()).collect();
-}
 ```
 
-## Best Practices
+Key methods: `filter`, `map`, `filter_map`, `fold`, `any`, `all`, `find`, `partition`, `enumerate`, `zip`, `collect`.
 
-### Cargo and Project Structure
+## Async/Await with Tokio
 
-```toml
-# Cargo.toml
-[package]
-name = "myproject"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.75"
+The agent should use tokio as the async runtime for all async operations in Loom.
 
-[dependencies]
-tokio = { version = "1.35", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
-anyhow = "1.0"
-
-[dev-dependencies]
-criterion = "0.5"
-mockall = "0.12"
-
-[features]
-default = []
-full = ["feature-a", "feature-b"]
-feature-a = []
-feature-b = ["dep:optional-dep"]
-
-[[bench]]
-name = "my_benchmark"
-harness = false
-```
-
-### Workspace Structure
-
-```text
-myworkspace/
-├── Cargo.toml          # Workspace root
-├── crates/
-│   ├── core/
-│   │   ├── Cargo.toml
-│   │   └── src/
-│   ├── api/
-│   │   ├── Cargo.toml
-│   │   └── src/
-│   └── cli/
-│       ├── Cargo.toml
-│       └── src/
-```
-
-```toml
-# Root Cargo.toml
-[workspace]
-members = ["crates/*"]
-resolver = "2"
-
-[workspace.dependencies]
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.35", features = ["full"] }
-```
-
-### CLI Applications with Clap
-
-```rust
-use clap::{Parser, Subcommand, ValueEnum, Args};
-use std::path::PathBuf;
-
-// Main CLI structure
-#[derive(Parser)]
-#[command(name = "loom")]
-#[command(about = "Agent orchestration CLI", long_about = None)]
-#[command(version)]
-struct Cli {
-    /// Optional config file
-    #[arg(short, long, value_name = "FILE")]
-    config: Option<PathBuf>,
-
-    /// Verbosity level (can be used multiple times: -v, -vv, -vvv)
-    #[arg(short, long, action = clap::ArgAction::Count)]
-    verbose: u8,
-
-    #[command(subcommand)]
-    command: Commands,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Initialize a new project
-    Init {
-        /// Project name
-        name: String,
-
-        /// Project template
-        #[arg(short, long, default_value = "default")]
-        template: String,
-
-        /// Skip git initialization
-        #[arg(long)]
-        no_git: bool,
-    },
-
-    /// Run the orchestrator daemon
-    Run {
-        /// Plan file to execute
-        #[arg(value_name = "PLAN")]
-        plan: Option<PathBuf>,
-
-        /// Run in foreground (don't daemonize)
-        #[arg(short, long)]
-        foreground: bool,
-    },
-
-    /// Stage management commands
-    Stage(StageArgs),
-
-    /// Knowledge base commands
-    Knowledge {
-        #[command(subcommand)]
-        command: KnowledgeCommands,
-    },
-
-    /// Show status
-    Status {
-        /// Output format
-        #[arg(short, long, value_enum, default_value = "table")]
-        format: OutputFormat,
-
-        /// Watch mode - refresh every N seconds
-        #[arg(short, long, value_name = "SECONDS")]
-        watch: Option<u64>,
-    },
-}
-
-#[derive(Args)]
-struct StageArgs {
-    #[command(subcommand)]
-    command: StageCommands,
-}
-
-#[derive(Subcommand)]
-enum StageCommands {
-    /// Mark stage as complete
-    Complete {
-        /// Stage ID
-        stage_id: String,
-    },
-    /// List all stages
-    List {
-        /// Show only active stages
-        #[arg(short, long)]
-        active: bool,
-    },
-    /// Show stage details
-    Show {
-        /// Stage ID
-        stage_id: String,
-    },
-}
-
-#[derive(Subcommand)]
-enum KnowledgeCommands {
-    /// Initialize knowledge base
-    Init,
-    /// List knowledge files
-    List,
-    /// Show knowledge content
-    Show {
-        /// Specific file to show (entry-points, patterns, conventions)
-        file: Option<String>,
-    },
-    /// Update knowledge file
-    Update {
-        /// File to update
-        file: String,
-        /// Content to append
-        content: String,
-    },
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-enum OutputFormat {
-    /// Human-readable table
-    Table,
-    /// JSON output
-    Json,
-    /// YAML output
-    Yaml,
-}
-
-// Main function
-fn main() -> Result<()> {
-    let cli = Cli::parse();
-
-    // Configure logging based on verbosity
-    let log_level = match cli.verbose {
-        0 => log::LevelFilter::Warn,
-        1 => log::LevelFilter::Info,
-        2 => log::LevelFilter::Debug,
-        _ => log::LevelFilter::Trace,
-    };
-    env_logger::Builder::new().filter_level(log_level).init();
-
-    // Load config if provided
-    let config = if let Some(config_path) = cli.config {
-        Config::load(&config_path)?
-    } else {
-        Config::default()
-    };
-
-    // Dispatch to command handlers
-    match cli.command {
-        Commands::Init { name, template, no_git } => {
-            commands::init(&name, &template, !no_git)?;
-        }
-        Commands::Run { plan, foreground } => {
-            commands::run(plan.as_deref(), foreground, &config)?;
-        }
-        Commands::Stage(args) => match args.command {
-            StageCommands::Complete { stage_id } => {
-                commands::stage::complete(&stage_id)?;
-            }
-            StageCommands::List { active } => {
-                commands::stage::list(active)?;
-            }
-            StageCommands::Show { stage_id } => {
-                commands::stage::show(&stage_id)?;
-            }
-        },
-        Commands::Knowledge { command } => match command {
-            KnowledgeCommands::Init => commands::knowledge::init()?,
-            KnowledgeCommands::List => commands::knowledge::list()?,
-            KnowledgeCommands::Show { file } => {
-                commands::knowledge::show(file.as_deref())?
-            }
-            KnowledgeCommands::Update { file, content } => {
-                commands::knowledge::update(&file, &content)?
-            }
-        },
-        Commands::Status { format, watch } => {
-            if let Some(interval) = watch {
-                commands::status::watch(format, interval)?;
-            } else {
-                commands::status::show(format)?;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-// Custom argument validators
-fn validate_stage_id(s: &str) -> Result<String, String> {
-    if s.is_empty() {
-        return Err("Stage ID cannot be empty".to_string());
-    }
-    if !s.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
-        return Err("Stage ID must contain only alphanumeric characters, hyphens, and underscores".to_string());
-    }
-    Ok(s.to_string())
-}
-```
-
-### Serialization with Serde
-
-```rust
-use serde::{Deserialize, Serialize, Deserializer, Serializer};
-use serde_json::Value as JsonValue;
-use std::collections::HashMap;
-use std::path::PathBuf;
-
-// Basic derive macros
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Config {
-    name: String,
-    version: String,
-    #[serde(default)]
-    enabled: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-}
-
-// Renaming fields
-#[derive(Debug, Serialize, Deserialize)]
-struct User {
-    #[serde(rename = "userId")]
-    user_id: String,
-    #[serde(rename = "userName")]
-    user_name: String,
-    // Flatten nested structure
-    #[serde(flatten)]
-    metadata: HashMap<String, String>,
-}
-
-// Default values and skip
-#[derive(Debug, Serialize, Deserialize)]
-struct Settings {
-    #[serde(default = "default_timeout")]
-    timeout: u64,
-    #[serde(default)]
-    retries: u32,
-    #[serde(skip)]
-    runtime_state: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    tags: Vec<String>,
-}
-
-fn default_timeout() -> u64 {
-    30
-}
-
-// Enum representations
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Status {
-    Active,
-    Inactive,
-    Pending,
-}
-
-// Tagged enum (externally tagged by default)
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "type")]
-enum Message {
-    Text { content: String },
-    Image { url: String, alt: Option<String> },
-    Video { url: String, duration: u32 },
-}
-
-// Internally tagged enum
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "kind", content = "data")]
-enum Event {
-    Created(String),
-    Updated { id: String, changes: Vec<String> },
-    Deleted(String),
-}
-
-// Untagged enum (tries each variant in order)
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-enum StringOrNumber {
-    Str(String),
-    Num(i64),
-}
-
-// Custom serialization
-#[derive(Debug)]
-struct Timestamp(chrono::DateTime<chrono::Utc>);
-
-impl Serialize for Timestamp {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_i64(self.0.timestamp())
-    }
-}
-
-impl<'de> Deserialize<'de> for Timestamp {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let timestamp = i64::deserialize(deserializer)?;
-        let dt = chrono::DateTime::from_timestamp(timestamp, 0)
-            .ok_or_else(|| serde::de::Error::custom("Invalid timestamp"))?;
-        Ok(Timestamp(dt))
-    }
-}
-
-// Using with helper functions
-#[derive(Debug, Serialize, Deserialize)]
-struct Task {
-    id: String,
-    #[serde(with = "chrono::serde::ts_seconds")]
-    created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(serialize_with = "serialize_path")]
-    #[serde(deserialize_with = "deserialize_path")]
-    file_path: PathBuf,
-}
-
-fn serialize_path<S>(path: &PathBuf, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    serializer.serialize_str(&path.to_string_lossy())
-}
-
-fn deserialize_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    Ok(PathBuf::from(s))
-}
-
-// Working with JSON
-fn json_examples() -> Result<()> {
-    let config = Config {
-        name: "test".to_string(),
-        version: "1.0".to_string(),
-        enabled: true,
-        description: Some("A test config".to_string()),
-    };
-
-    // Serialize to JSON string
-    let json = serde_json::to_string(&config)?;
-    let json_pretty = serde_json::to_string_pretty(&config)?;
-
-    // Deserialize from JSON string
-    let parsed: Config = serde_json::from_str(&json)?;
-
-    // Work with generic JSON values
-    let mut value: JsonValue = serde_json::from_str(&json)?;
-    if let Some(obj) = value.as_object_mut() {
-        obj.insert("extra".to_string(), JsonValue::Bool(true));
-    }
-
-    // Convert to specific type
-    let config2: Config = serde_json::from_value(value)?;
-
-    Ok(())
-}
-
-// Working with TOML
-fn toml_examples() -> Result<()> {
-    let config = Config {
-        name: "test".to_string(),
-        version: "1.0".to_string(),
-        enabled: true,
-        description: None,
-    };
-
-    // Serialize to TOML
-    let toml = toml::to_string(&config)?;
-    let toml_pretty = toml::to_string_pretty(&config)?;
-
-    // Deserialize from TOML
-    let parsed: Config = toml::from_str(&toml)?;
-
-    Ok(())
-}
-
-// Working with YAML
-fn yaml_examples() -> Result<()> {
-    let config = Config {
-        name: "test".to_string(),
-        version: "1.0".to_string(),
-        enabled: true,
-        description: None,
-    };
-
-    // Serialize to YAML
-    let yaml = serde_yaml::to_string(&config)?;
-
-    // Deserialize from YAML
-    let parsed: Config = serde_yaml::from_str(&yaml)?;
-
-    Ok(())
-}
-
-// Generic serialization function
-fn serialize_any<T: Serialize>(value: &T, format: &str) -> Result<String> {
-    match format {
-        "json" => Ok(serde_json::to_string_pretty(value)?),
-        "toml" => Ok(toml::to_string_pretty(value)?),
-        "yaml" => Ok(serde_yaml::to_string(value)?),
-        _ => Err(anyhow::anyhow!("Unsupported format: {}", format)),
-    }
-}
-```
-
-### Async/Await with Tokio
+### Core Patterns
 
 ```rust
 use tokio::sync::{mpsc, Mutex, RwLock};
@@ -757,22 +158,7 @@ use tokio::time::{sleep, Duration, timeout};
 // Basic async function
 async fn fetch_data(url: &str) -> Result<String> {
     let response = reqwest::get(url).await?;
-    let body = response.text().await?;
-    Ok(body)
-}
-
-// Concurrent execution with join_all
-async fn fetch_all(urls: Vec<String>) -> Vec<Result<String>> {
-    let futures: Vec<_> = urls.iter().map(|url| fetch_data(url)).collect();
-    futures::future::join_all(futures).await
-}
-
-// Select multiple futures - first to complete wins
-async fn fetch_with_fallback(primary: &str, fallback: &str) -> Result<String> {
-    tokio::select! {
-        result = fetch_data(primary) => result,
-        result = fetch_data(fallback) => result,
-    }
+    Ok(response.text().await?)
 }
 
 // Timeout for async operations
@@ -787,580 +173,182 @@ struct AppState {
     counter: Arc<Mutex<u64>>,
     cache: Arc<RwLock<HashMap<String, String>>>,
 }
+```
 
-impl AppState {
-    async fn increment(&self) -> u64 {
-        let mut counter = self.counter.lock().await;
-        *counter += 1;
-        *counter
-    }
+### Channel Communication
 
-    // RwLock for read-heavy workloads
-    async fn get_cached(&self, key: &str) -> Option<String> {
-        let cache = self.cache.read().await;
-        cache.get(key).cloned()
-    }
+- **mpsc** for multi-producer, single-consumer messaging between tasks.
+- **broadcast** for multi-consumer messaging where all receivers get every message.
+- **oneshot** for single-value responses (request-reply patterns).
+- Use `tokio::task::spawn_blocking` for CPU-intensive work that would block the async runtime.
+- Use `tokio::select!` to race multiple futures and proceed with the first to complete.
 
-    async fn update_cache(&self, key: String, value: String) {
-        let mut cache = self.cache.write().await;
-        cache.insert(key, value);
-    }
+## Cargo and Project Structure
+
+### Cargo.toml Essentials
+
+```toml
+[package]
+name = "myproject"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1.35", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
+anyhow = "1.0"
+
+[dev-dependencies]
+criterion = "0.5"
+mockall = "0.12"
+```
+
+### Workspace Structure
+
+```toml
+# Root Cargo.toml
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.35", features = ["full"] }
+```
+
+The agent should use workspace dependencies to keep versions consistent across crates.
+
+## CLI Development with Clap
+
+The agent should use clap's derive API for CLI argument parsing.
+
+```rust
+use clap::{Parser, Subcommand, ValueEnum};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "loom", about = "Agent orchestration CLI", version)]
+struct Cli {
+    #[arg(short, long, value_name = "FILE")]
+    config: Option<PathBuf>,
+
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    #[command(subcommand)]
+    command: Commands,
 }
 
-// Channel communication patterns
-async fn producer_consumer() {
-    let (tx, mut rx) = mpsc::channel(32);
-
-    // Producer task
-    tokio::spawn(async move {
-        for i in 0..10 {
-            if tx.send(i).await.is_err() {
-                break; // Receiver dropped
-            }
-        }
-    });
-
-    // Consumer
-    while let Some(value) = rx.recv().await {
-        println!("Received: {}", value);
-    }
+#[derive(Subcommand)]
+enum Commands {
+    Init { name: String },
+    Run {
+        #[arg(value_name = "PLAN")]
+        plan: Option<PathBuf>,
+    },
+    Status {
+        #[arg(short, long, value_enum, default_value = "table")]
+        format: OutputFormat,
+    },
 }
 
-// Multiple producers with broadcast
-use tokio::sync::broadcast;
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
+enum OutputFormat { Table, Json, Yaml }
+```
 
-async fn broadcast_example() {
-    let (tx, mut rx1) = broadcast::channel(16);
-    let mut rx2 = tx.subscribe();
+## Serialization with Serde
 
-    tokio::spawn(async move {
-        tx.send("message").unwrap();
-    });
+### Common Derive Patterns
 
-    tokio::join!(
-        async { println!("rx1: {:?}", rx1.recv().await) },
-        async { println!("rx2: {:?}", rx2.recv().await) },
-    );
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Config {
+    name: String,
+    #[serde(default)]
+    enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(rename = "userId")]
+    user_id: String,
 }
 
-// Oneshot for single-value communication
-use tokio::sync::oneshot;
-
-async fn compute_task() -> i32 {
-    sleep(Duration::from_secs(1)).await;
-    42
-}
-
-async fn oneshot_example() {
-    let (tx, rx) = oneshot::channel();
-
-    tokio::spawn(async move {
-        let result = compute_task().await;
-        let _ = tx.send(result);
-    });
-
-    match rx.await {
-        Ok(value) => println!("Got: {}", value),
-        Err(_) => println!("Sender dropped"),
-    }
-}
-
-// Spawning blocking tasks
-async fn cpu_intensive_work() -> Result<String> {
-    tokio::task::spawn_blocking(|| {
-        // CPU-intensive operation that would block async runtime
-        std::thread::sleep(Duration::from_secs(2));
-        "done".to_string()
-    })
-    .await
-    .context("Task panicked")
-}
-
-// Tokio runtime setup
-fn main() {
-    // Multi-threaded runtime
-    let runtime = tokio::runtime::Runtime::new().unwrap();
-    runtime.block_on(async {
-        fetch_data("http://example.com").await.ok();
-    });
-
-    // Or use the macro
-    #[tokio::main]
-    async fn main() {
-        // async main function
-    }
-
-    // Single-threaded runtime for lightweight apps
-    #[tokio::main(flavor = "current_thread")]
-    async fn main() {
-        // async main with single thread
-    }
+// Tagged enum for polymorphic serialization
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum Message {
+    Text { content: String },
+    Image { url: String, alt: Option<String> },
 }
 ```
+
+### Key Serde Attributes
+
+- `#[serde(default)]` uses `Default::default()` for missing fields.
+- `#[serde(skip_serializing_if = "Option::is_none")]` omits `None` values from output.
+- `#[serde(rename = "...")]` maps Rust field names to different serialized names.
+- `#[serde(flatten)]` inlines nested struct fields into the parent.
+- `#[serde(tag = "type")]` for internally tagged enums (common for JSON APIs).
+- `#[serde(untagged)]` tries each variant in order (useful for `StringOrNumber` unions).
 
 ## Common Patterns
 
-### Error Handling Patterns
-
-```rust
-use thiserror::Error;
-use anyhow::{Context, Result, bail, ensure};
-use std::io;
-
-// Library error types with thiserror
-#[derive(Error, Debug)]
-pub enum ParseError {
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
-
-    #[error("Invalid syntax at line {line}, column {column}: {message}")]
-    Syntax {
-        line: usize,
-        column: usize,
-        message: String,
-    },
-
-    #[error("Unknown token: {0}")]
-    UnknownToken(String),
-
-    #[error("Expected {expected}, found {found}")]
-    Unexpected { expected: String, found: String },
-}
-
-// Application error types with context
-pub type AppResult<T> = Result<T, AppError>;
-
-#[derive(Error, Debug)]
-pub enum AppError {
-    #[error("Parse error")]
-    Parse(#[from] ParseError),
-
-    #[error("Configuration error: {0}")]
-    Config(String),
-
-    #[error("Stage not found: {0}")]
-    StageNotFound(String),
-
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-}
-
-// Error context chain
-fn load_and_parse_config(path: &str) -> Result<Config> {
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("Failed to read config file: {}", path))?;
-
-    let config: Config = toml::from_str(&content)
-        .with_context(|| format!("Failed to parse TOML in {}", path))?;
-
-    validate_config(&config)
-        .context("Config validation failed")?;
-
-    Ok(config)
-}
-
-// Early validation with ensure
-fn validate_config(config: &Config) -> Result<()> {
-    ensure!(!config.name.is_empty(), "Config name cannot be empty");
-    ensure!(config.port > 0, "Port must be greater than 0");
-    ensure!(config.port < 65536, "Port must be less than 65536");
-
-    if config.stages.is_empty() {
-        bail!("Config must have at least one stage");
-    }
-
-    Ok(())
-}
-
-// Option to Result conversion patterns
-fn get_stage(id: &str) -> Result<Stage> {
-    let stage = find_stage(id)
-        .ok_or_else(|| AppError::StageNotFound(id.to_string()))?;
-    Ok(stage)
-}
-
-// Result unwrapping strategies
-fn result_handling_examples() {
-    let result: Result<String> = fetch_data();
-
-    // Propagate with ?
-    let data = result?;
-
-    // Provide default
-    let data = result.unwrap_or_default();
-    let data = result.unwrap_or_else(|| "fallback".to_string());
-
-    // Convert error type
-    let data = result.map_err(|e| AppError::Other(e))?;
-
-    // Explicit handling
-    let data = match result {
-        Ok(d) => d,
-        Err(e) => {
-            log::error!("Failed to fetch: {}", e);
-            return Err(e);
-        }
-    };
-
-    // Inspect without consuming
-    if let Err(ref e) = result {
-        log::warn!("Warning: {}", e);
-    }
-
-    // Chain operations
-    let processed = result
-        .and_then(|data| parse(&data))
-        .and_then(|parsed| validate(&parsed))
-        .map(|validated| transform(validated))?;
-}
-
-// Multiple error sources
-fn multiple_operations() -> Result<()> {
-    let file1 = std::fs::read_to_string("file1.txt")
-        .context("Failed to read file1")?;
-    let file2 = std::fs::read_to_string("file2.txt")
-        .context("Failed to read file2")?;
-
-    let result = process(&file1, &file2)
-        .context("Failed to process files")?;
-
-    save_result(&result)
-        .context("Failed to save result")?;
-
-    Ok(())
-}
-
-// Collecting Results
-fn process_all_files(paths: &[&str]) -> Result<Vec<Content>> {
-    // Stop on first error
-    paths.iter()
-        .map(|path| load_file(path))
-        .collect::<Result<Vec<_>>>()
-}
-
-fn process_all_files_partial(paths: &[&str]) -> Vec<Result<Content>> {
-    // Continue on errors, return all results
-    paths.iter()
-        .map(|path| load_file(path))
-        .collect()
-}
-
-fn process_all_files_separate(paths: &[&str]) -> (Vec<Content>, Vec<anyhow::Error>) {
-    // Separate successes from failures
-    let results: Vec<_> = paths.iter()
-        .map(|path| load_file(path))
-        .collect();
-
-    let mut successes = Vec::new();
-    let mut failures = Vec::new();
-
-    for result in results {
-        match result {
-            Ok(content) => successes.push(content),
-            Err(e) => failures.push(e),
-        }
-    }
-
-    (successes, failures)
-}
-```
-
 ### Builder Pattern
+
+The agent should use the builder pattern for structs with many optional fields.
 
 ```rust
 #[derive(Default)]
 pub struct RequestBuilder {
     url: Option<String>,
-    method: Method,
     headers: HashMap<String, String>,
-    body: Option<Vec<u8>>,
     timeout: Duration,
 }
 
 impl RequestBuilder {
-    pub fn new() -> Self {
-        Self {
-            method: Method::GET,
-            timeout: Duration::from_secs(30),
-            ..Default::default()
-        }
+    pub fn new() -> Self { Self { timeout: Duration::from_secs(30), ..Default::default() } }
+    pub fn url(mut self, url: impl Into<String>) -> Self { self.url = Some(url.into()); self }
+    pub fn header(mut self, key: impl Into<String>, val: impl Into<String>) -> Self {
+        self.headers.insert(key.into(), val.into()); self
     }
-
-    pub fn url(mut self, url: impl Into<String>) -> Self {
-        self.url = Some(url.into());
-        self
-    }
-
-    pub fn method(mut self, method: Method) -> Self {
-        self.method = method;
-        self
-    }
-
-    pub fn header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.headers.insert(key.into(), value.into());
-        self
-    }
-
-    pub fn body(mut self, body: impl Into<Vec<u8>>) -> Self {
-        self.body = Some(body.into());
-        self
-    }
-
     pub fn build(self) -> Result<Request, BuildError> {
         let url = self.url.ok_or(BuildError::MissingUrl)?;
-        Ok(Request {
-            url,
-            method: self.method,
-            headers: self.headers,
-            body: self.body,
-            timeout: self.timeout,
-        })
+        Ok(Request { url, headers: self.headers, timeout: self.timeout })
     }
 }
 ```
 
 ### Newtype Pattern
 
+The agent should use newtypes for type-safe domain identifiers to prevent mixing up IDs at compile time.
+
 ```rust
-// Type safety through newtype
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UserId(String);
 
 impl UserId {
-    pub fn new(id: impl Into<String>) -> Self {
-        UserId(id.into())
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct OrderId(String);
-
-// Now these are different types - can't mix them up
-fn get_user(id: UserId) -> Option<User> { /* ... */ }
-fn get_order(id: OrderId) -> Option<Order> { /* ... */ }
-```
-
-### Smart Pointers and Interior Mutability
-
-```rust
-use std::rc::Rc;
-use std::sync::{Arc, Mutex, RwLock};
-use std::cell::{RefCell, Cell};
-
-// Box - heap allocation, single owner
-fn box_example() {
-    // Large value on heap instead of stack
-    let large_data = Box::new([0u8; 10000]);
-
-    // Recursive types require Box
-    enum List {
-        Cons(i32, Box<List>),
-        Nil,
-    }
-}
-
-// Rc - shared ownership (single-threaded)
-fn rc_example() {
-    let shared = Rc::new(vec![1, 2, 3]);
-    let ref1 = Rc::clone(&shared);
-    let ref2 = Rc::clone(&shared);
-
-    println!("Reference count: {}", Rc::strong_count(&shared)); // 3
-
-    // Check before cloning
-    if Rc::strong_count(&shared) < 10 {
-        let ref3 = Rc::clone(&shared);
-    }
-}
-
-// Arc - shared ownership (multi-threaded)
-fn arc_example() {
-    let shared = Arc::new(vec![1, 2, 3]);
-
-    let handles: Vec<_> = (0..5)
-        .map(|i| {
-            let data = Arc::clone(&shared);
-            std::thread::spawn(move || {
-                println!("Thread {}: {:?}", i, data);
-            })
-        })
-        .collect();
-
-    for handle in handles {
-        handle.join().unwrap();
-    }
-}
-
-// RefCell - interior mutability (single-threaded)
-fn refcell_example() {
-    let data = RefCell::new(vec![1, 2, 3]);
-
-    // Multiple immutable borrows
-    {
-        let borrow1 = data.borrow();
-        let borrow2 = data.borrow();
-        println!("{:?}", borrow1);
-    } // Borrows dropped here
-
-    // Mutable borrow
-    data.borrow_mut().push(4);
-
-    // try_borrow for runtime check
-    match data.try_borrow_mut() {
-        Ok(mut b) => b.push(5),
-        Err(_) => println!("Already borrowed"),
-    }
-}
-
-// Cell - interior mutability for Copy types
-fn cell_example() {
-    let counter = Cell::new(0);
-
-    let increment = || {
-        let current = counter.get();
-        counter.set(current + 1);
-    };
-
-    increment();
-    increment();
-    assert_eq!(counter.get(), 2);
-}
-
-// Arc<Mutex<T>> - shared mutable state (multi-threaded)
-fn arc_mutex_example() {
-    let counter = Arc::new(Mutex::new(0));
-    let mut handles = vec![];
-
-    for _ in 0..10 {
-        let counter = Arc::clone(&counter);
-        let handle = std::thread::spawn(move || {
-            let mut num = counter.lock().unwrap();
-            *num += 1;
-        });
-        handles.push(handle);
-    }
-
-    for handle in handles {
-        handle.join().unwrap();
-    }
-
-    println!("Result: {}", *counter.lock().unwrap());
-}
-
-// Arc<RwLock<T>> - read-heavy workloads
-fn arc_rwlock_example() {
-    let cache = Arc::new(RwLock::new(HashMap::new()));
-
-    // Multiple readers
-    let readers: Vec<_> = (0..5)
-        .map(|i| {
-            let cache = Arc::clone(&cache);
-            std::thread::spawn(move || {
-                let cache = cache.read().unwrap();
-                if let Some(value) = cache.get(&i) {
-                    println!("Read: {}", value);
-                }
-            })
-        })
-        .collect();
-
-    // Single writer
-    let writer = {
-        let cache = Arc::clone(&cache);
-        std::thread::spawn(move || {
-            let mut cache = cache.write().unwrap();
-            cache.insert(0, "value".to_string());
-        })
-    };
-
-    for reader in readers {
-        reader.join().unwrap();
-    }
-    writer.join().unwrap();
-}
-
-// Rc<RefCell<T>> - shared mutable state (single-threaded)
-struct Node {
-    value: i32,
-    children: Vec<Rc<RefCell<Node>>>,
-}
-
-fn rc_refcell_tree() {
-    let root = Rc::new(RefCell::new(Node {
-        value: 1,
-        children: vec![],
-    }));
-
-    let child = Rc::new(RefCell::new(Node {
-        value: 2,
-        children: vec![],
-    }));
-
-    root.borrow_mut().children.push(Rc::clone(&child));
-
-    // Modify child through shared reference
-    child.borrow_mut().value = 3;
-}
-
-// Weak references to prevent cycles
-use std::rc::Weak;
-
-struct Parent {
-    children: Vec<Rc<RefCell<Child>>>,
-}
-
-struct Child {
-    parent: Weak<RefCell<Parent>>,
-}
-
-fn weak_reference_example() {
-    let parent = Rc::new(RefCell::new(Parent { children: vec![] }));
-
-    let child = Rc::new(RefCell::new(Child {
-        parent: Rc::downgrade(&parent),
-    }));
-
-    parent.borrow_mut().children.push(Rc::clone(&child));
-
-    // Access parent from child
-    if let Some(parent) = child.borrow().parent.upgrade() {
-        println!("Parent exists");
-    }
-}
-
-// Pattern: Interior mutability for caching
-struct Database {
-    cache: RefCell<HashMap<String, String>>,
-}
-
-impl Database {
-    fn get(&self, key: &str) -> Option<String> {
-        // Check cache with immutable self
-        if let Some(value) = self.cache.borrow().get(key) {
-            return Some(value.clone());
-        }
-
-        // Fetch from database
-        let value = self.fetch_from_db(key)?;
-
-        // Update cache with immutable self
-        self.cache.borrow_mut().insert(key.to_string(), value.clone());
-
-        Some(value)
-    }
-
-    fn fetch_from_db(&self, key: &str) -> Option<String> {
-        // Database query
-        None
-    }
+    pub fn new(id: impl Into<String>) -> Self { UserId(id.into()) }
+    pub fn as_str(&self) -> &str { &self.0 }
 }
 ```
 
-### Testing
+### Smart Pointers Quick Reference
+
+| Type | Use Case |
+|------|----------|
+| `Box<T>` | Heap allocation, single owner, recursive types |
+| `Rc<T>` | Shared ownership, single-threaded |
+| `Arc<T>` | Shared ownership, multi-threaded |
+| `RefCell<T>` | Interior mutability, single-threaded (runtime borrow checks) |
+| `Mutex<T>` | Interior mutability, multi-threaded (blocking lock) |
+| `RwLock<T>` | Interior mutability, multi-threaded (read-heavy workloads) |
+| `Weak<T>` | Non-owning reference to break reference cycles |
+
+Common combinations: `Arc<Mutex<T>>` for shared mutable state across threads; `Rc<RefCell<T>>` for shared mutable state in single-threaded contexts.
+
+## Testing
 
 ```rust
 #[cfg(test)]
@@ -1369,12 +357,11 @@ mod tests {
 
     #[test]
     fn test_basic() {
-        let result = add(2, 3);
-        assert_eq!(result, 5);
+        assert_eq!(add(2, 3), 5);
     }
 
     #[test]
-    fn test_with_result() -> Result<(), Box<dyn Error>> {
+    fn test_with_result() -> Result<(), Box<dyn std::error::Error>> {
         let config = parse_config("valid config")?;
         assert_eq!(config.name, "test");
         Ok(())
@@ -1382,117 +369,24 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "divide by zero")]
-    fn test_panic() {
-        divide(1, 0);
-    }
+    fn test_panic() { divide(1, 0); }
 
-    // Async tests with tokio
     #[tokio::test]
-    async fn test_async_function() {
+    async fn test_async() {
         let result = fetch_data("http://example.com").await;
         assert!(result.is_ok());
     }
-
-    // Property-based testing with proptest
-    use proptest::prelude::*;
-
-    proptest! {
-        #[test]
-        fn test_parse_roundtrip(s in "[a-z]+") {
-            let parsed = parse(&s)?;
-            let serialized = serialize(&parsed);
-            prop_assert_eq!(s, serialized);
-        }
-    }
 }
 ```
 
-## Anti-Patterns
+## Anti-Patterns to Avoid
 
-### Avoid These Practices
-
-```rust
-// BAD: Unnecessary clone
-fn process(items: &Vec<String>) {
-    for item in items.clone() {  // Unnecessary allocation
-        println!("{}", item);
-    }
-}
-
-// GOOD: Iterate by reference
-fn process(items: &[String]) {
-    for item in items {
-        println!("{}", item);
-    }
-}
-
-// BAD: Using unwrap/expect in library code
-fn parse_config(s: &str) -> Config {
-    serde_json::from_str(s).unwrap()  // Panics on invalid input
-}
-
-// GOOD: Return Result and let caller handle errors
-fn parse_config(s: &str) -> Result<Config, serde_json::Error> {
-    serde_json::from_str(s)
-}
-
-// BAD: Excessive use of Rc<RefCell<T>>
-struct Node {
-    value: i32,
-    children: Vec<Rc<RefCell<Node>>>,
-}
-
-// GOOD: Consider arena allocation or indices
-struct Arena {
-    nodes: Vec<Node>,
-}
-struct Node {
-    value: i32,
-    children: Vec<usize>,  // Indices into arena
-}
-
-// BAD: String concatenation in loops
-fn build_message(parts: &[&str]) -> String {
-    let mut result = String::new();
-    for part in parts {
-        result = result + part + ", ";  // Creates new String each iteration
-    }
-    result
-}
-
-// GOOD: Use push_str or collect
-fn build_message(parts: &[&str]) -> String {
-    parts.join(", ")
-}
-
-// BAD: Boxing errors unnecessarily
-fn parse(s: &str) -> Result<Data, Box<dyn Error>> {
-    // For libraries, use concrete error types
-}
-
-// GOOD: Use concrete error types in libraries
-fn parse(s: &str) -> Result<Data, ParseError> {
-    // thiserror for library errors, anyhow for applications
-}
-
-// BAD: Unsafe without justification
-unsafe fn get_unchecked(slice: &[i32], index: usize) -> i32 {
-    *slice.get_unchecked(index)
-}
-
-// GOOD: Safe by default, unsafe with clear invariants
-fn get_unchecked(slice: &[i32], index: usize) -> i32 {
-    // SAFETY: Caller must ensure index < slice.len()
-    // Only use when bounds checking is a proven bottleneck
-    debug_assert!(index < slice.len());
-    unsafe { *slice.get_unchecked(index) }
-}
-
-// BAD: Ignoring must_use
-let _ = fs::remove_file("temp.txt");  // Error silently ignored
-
-// GOOD: Handle the result
-fs::remove_file("temp.txt").ok();  // Explicitly ignore
-// or
-fs::remove_file("temp.txt")?;  // Propagate error
-```
+| Anti-Pattern | Preferred Approach |
+|---|---|
+| Unnecessary `.clone()` in loops | Iterate by reference (`&[T]` instead of `&Vec<T>`) |
+| `.unwrap()` / `.expect()` in library code | Return `Result` and let the caller handle errors |
+| String concatenation in loops (`result + part`) | Use `parts.join(", ")` or `push_str` |
+| `Box<dyn Error>` in library APIs | Use concrete error types via `thiserror` |
+| `unsafe` without documented invariants | Safe by default; `unsafe` only with `// SAFETY:` comment and `debug_assert!` |
+| Ignoring `#[must_use]` results | Handle with `?` or explicitly ignore with `.ok()` |
+| Excessive `Rc<RefCell<T>>` for graphs | Consider arena allocation with index-based references |


### PR DESCRIPTION
Hey @cosmix 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/fbd90a1c-70e1-4da0-8713-c6c44c4a5580" />



Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| loom-accessibility | 0% | 74% | +74% |
| loom-api-design | 0% | 83% | +83% |
| loom-debugging | 0% | 85% | +85% |
| loom-docker | 0% | 83% | +83% |
| loom-rust | 0% | 83% | +83% |

All five skills previously scored **0%** because the YAML frontmatter `description` fields contained unquoted colons and commas that broke parsing — the LLM judge never even ran. This same issue affects 45 of the 61 skills in the repo (the fix is the same pattern for all of them). This PR intentionally caps at five skills to keep it reviewable; the included workflow (below) will surface Tessl feedback on future `SKILL.md` changes so the rest can improve incrementally.

<details>
<summary>Changes summary</summary>

**Frontmatter fixes (all 5 skills):**
- Quoted `description` fields to fix YAML parsing errors
- Moved trigger terms from description into a separate `trigger-keywords` field
- Added `allowed-tools` field for proper tool scoping

**Content optimization:**
- **loom-accessibility**: 1,223 → 307 lines — trimmed verbose WCAG checklists and TypeScript interfaces while preserving ARIA patterns, focus management, and testing examples
- **loom-api-design**: 336 → 287 lines — tightened workflow steps and ensured third-person voice throughout; kept all REST/GraphQL/gRPC examples
- **loom-debugging**: 454 → 180 lines — condensed from 7 to 4 high-value examples, streamlined specialized domains (flaky tests, data pipelines, ML models)
- **loom-docker**: 1,131 → 290 lines — removed CI/CD section (belongs in loom-ci-cd), condensed troubleshooting, kept best multi-stage build examples
- **loom-rust**: 1,499 → 393 lines — consolidated ownership/error handling/async patterns, replaced verbose examples with reference tables, preserved Loom project context

All changes preserve domain expertise and terminology.

</details>

## Tessl Skill Review GitHub Action

This PR also adds `.github/workflows/skill-review.yml` — a lightweight GitHub Action that automatically reviews any `SKILL.md` changes in future PRs.

- **What it does:** On PRs that touch `**/SKILL.md`, the workflow runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) and posts **one** PR comment with Tessl scores and feedback (updated on new pushes).
- **Zero extra accounts:** Contributors don't need a Tessl login — only the repo's default `GITHUB_TOKEN` is used to post the comment.
- **Non-blocking by default:** The check is feedback-only — no surprise red CI. No `fail-threshold` is set.
- **Not a build replacement:** This is review automation for skill markdown only, not a substitute for your existing CI/CD pipeline.
- **Optional quality gate:** If you ever want PRs to fail on low skill scores, just add `with: fail-threshold: 70` (or whatever threshold you prefer).
- **Why only 5 skills here:** This PR caps manual optimization so it stays reviewable. After merge, every PR that touches a `SKILL.md` gets automatic review comments — so the rest of the 56 skills can improve incrementally.

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
