### PR TITLE
Make the daemon's picture of a live session true

### DIFF
--- a/loom/maintainability-baseline.txt
+++ b/loom/maintainability-baseline.txt
@@ -39,7 +39,7 @@ file src/models/stage/methods.rs 811
 file src/models/stage/types.rs 1205
 file src/orchestrator/adjudication/mod.rs 695
 file src/orchestrator/adjudication/prompt.rs 491
-file src/orchestrator/core/event_handler.rs 468
+file src/orchestrator/core/event_handler.rs 467
 file src/orchestrator/core/merge_handler.rs 1300
 file src/orchestrator/core/orchestrator.rs 574
 file src/orchestrator/core/recovery.rs 1621
@@ -210,7 +210,7 @@ function src/orchestrator/auto_merge.rs attempt_auto_merge 63
 function src/orchestrator/core/completion_handler.rs handle_stage_completed 78
 function src/orchestrator/core/crash_handler.rs handle_session_crashed 156
 function src/orchestrator/core/event_handler.rs handle_budget_exceeded 56
-function src/orchestrator/core/event_handler.rs handle_one_event 117
+function src/orchestrator/core/event_handler.rs handle_one_event 115
 function src/orchestrator/core/merge_handler.rs finalize_merge_resolution 97
 function src/orchestrator/core/merge_handler.rs handle_merge_session_completed 168
 function src/orchestrator/core/merge_handler.rs read_plan_level_auto_merge 61
@@ -233,7 +233,7 @@ function src/orchestrator/core/stage_executor.rs start_ready_stages 67
 function src/orchestrator/core/stage_executor.rs start_stage 430
 function src/orchestrator/merge_attribution.rs attribute_main_repo_merge 101
 function src/orchestrator/merge_attribution.rs reconcile_main_repo_active_merge 64
-function src/orchestrator/monitor/detection.rs detect_heartbeat_events 99
+function src/orchestrator/monitor/detection.rs detect_heartbeat_events 96
 function src/orchestrator/monitor/detection.rs detect_session_changes 107
 function src/orchestrator/monitor/detection.rs detect_stage_changes 62
 function src/orchestrator/monitor/heartbeat.rs poll 52

--- a/loom/src/models/session/methods.rs
+++ b/loom/src/models/session/methods.rs
@@ -106,6 +106,36 @@ impl Session {
         self.last_active = Utc::now();
     }
 
+    /// Apply an observed heartbeat to this session.
+    ///
+    /// A heartbeat is the only ongoing evidence the daemon has that a live
+    /// session is doing anything: the hooks rewrite
+    /// `.work/heartbeat/<stage-id>.json` after every tool call. Recording it
+    /// here is what keeps `last_active` honest — without it the field is set
+    /// once by [`Session::assign_to_stage`] at spawn and never again, so every
+    /// duration derived from it reports a session's entire lifetime as idle.
+    ///
+    /// `context_percent` is threaded through but is `None` in practice today:
+    /// both `hooks/session-start.sh` and `hooks/post-tool-use.sh` write a
+    /// literal `null`, because Claude Code's PostToolUse payload does not carry
+    /// context usage. It is applied when present rather than assumed absent, so
+    /// that a hook learning the field becomes a hook-only change instead of a
+    /// second wiring job here.
+    pub fn record_heartbeat(&mut self, context_percent: Option<f32>) {
+        self.last_active = Utc::now();
+
+        // Only a real, in-range reading may move context_tokens. A missing or
+        // nonsensical percentage leaves the previous value alone rather than
+        // zeroing it: `is_context_exhausted` reads this field, and resetting it
+        // to 0 would silently retract a handoff that was already due.
+        let Some(percent) = context_percent else {
+            return;
+        };
+        if percent.is_finite() && (0.0..=100.0).contains(&percent) && self.context_limit > 0 {
+            self.context_tokens = ((percent / 100.0) * self.context_limit as f32).round() as u32;
+        }
+    }
+
     pub fn context_usage_percent(&self) -> f32 {
         if self.context_limit == 0 {
             return 0.0;

--- a/loom/src/orchestrator/core/event_handler.rs
+++ b/loom/src/orchestrator/core/event_handler.rs
@@ -6,6 +6,7 @@ use colored::Colorize;
 use std::path::PathBuf;
 
 use crate::models::stage::{Stage, StageStatus};
+use crate::orchestrator::monitor::parked::hung_warning;
 use crate::orchestrator::monitor::MonitorEvent;
 use crate::orchestrator::signals::remove_signal;
 
@@ -197,22 +198,20 @@ impl Orchestrator {
                 stale_duration_secs,
                 timeout_secs,
                 last_activity,
+                finished_without_completing,
             } => {
                 clear_status_line();
-                let stage_info = stage_id
-                    .as_ref()
-                    .map(|s| format!(" (stage '{s}')"))
-                    .unwrap_or_default();
-                let activity_info = last_activity
-                    .as_ref()
-                    .map(|a| format!(", last: {a}"))
-                    .unwrap_or_default();
-                // ADVISORY ONLY: nothing is killed and nothing is retried. Naming
-                // the budget tells the operator whether to raise the stage's
-                // `subagent_timeout_secs` or go look at the session.
-                eprintln!(
-                        "Warning: Session '{session_id}'{stage_info} appears hung (no heartbeat for {stale_duration_secs}s, budget {timeout_secs}s{activity_info})"
-                    );
+                // ADVISORY ONLY: nothing is killed and nothing is retried. The
+                // wording, and the parked/stuck split, live in monitor::parked.
+                let warning = hung_warning(
+                    &session_id,
+                    stage_id.as_deref(),
+                    stale_duration_secs,
+                    timeout_secs,
+                    last_activity.as_deref(),
+                    finished_without_completing,
+                );
+                eprintln!("{warning}");
             }
             MonitorEvent::HeartbeatReceived {
                 stage_id,

--- a/loom/src/orchestrator/core/event_handler.rs
+++ b/loom/src/orchestrator/core/event_handler.rs
@@ -215,12 +215,12 @@ impl Orchestrator {
                     );
             }
             MonitorEvent::HeartbeatReceived {
-                stage_id: _,
-                session_id: _,
-                context_percent: _,
+                stage_id,
+                session_id,
+                context_percent,
                 last_tool: _,
             } => {
-                // Heartbeat events are silent - just used for internal tracking
+                self.apply_heartbeat(&stage_id, &session_id, context_percent)?;
             }
             MonitorEvent::BudgetExceeded {
                 session_id,

--- a/loom/src/orchestrator/core/heartbeat_apply.rs
+++ b/loom/src/orchestrator/core/heartbeat_apply.rs
@@ -1,0 +1,215 @@
+//! Applying an observed heartbeat to the session record it describes.
+//!
+//! # Why this is a module and not four lines in `event_handler`
+//!
+//! `HeartbeatWatcher` polls `.work/heartbeat/<stage-id>.json` and the monitor
+//! turns every update into a [`MonitorEvent::HeartbeatReceived`]. Until this
+//! module existed that event's handler was an empty block whose comment claimed
+//! the data was "just used for internal tracking" — nothing tracked it, and
+//! [`Session::update_context`], the only method that touched `context_tokens`,
+//! had no non-test caller anywhere in the crate.
+//!
+//! The consequence was silent and total. `Session::last_active` kept its spawn
+//! timestamp for the whole life of every session and `context_tokens` stayed
+//! `0`, so:
+//!
+//! - [`Session::is_context_exhausted`] could never return `true`, and
+//!   `handoff::detector` therefore never saw a session worth handing off —
+//!   `CONTEXT_CRITICAL_THRESHOLD` was unreachable in production;
+//! - `commands/status/data/collector` treats `context_tokens == 0` as "no
+//!   reading", so the dashboard's context column was blank for healthy and
+//!   exhausted sessions alike;
+//! - `orchestrator/signals/generate` handed every resumed agent a context
+//!   figure of 0%;
+//! - every duration derived from `last_active` measured from spawn, which reads
+//!   as "idle since it started" for a session that has been working for hours.
+//!
+//! Observed 2026-08-24 on an eight-stage plan: all five session records carried
+//! `last_active` equal to their spawn timestamp and `context_tokens: 0`, while
+//! `.work/heartbeat/<stage>.json` was being rewritten correctly by the hooks the
+//! whole time. The data was arriving and being dropped one layer above where it
+//! was needed.
+//!
+//! # What this does NOT change
+//!
+//! Hung detection stays advisory. `MonitorEvent::SessionHung` still only warns —
+//! nothing here kills, retries, or transitions a stage, and that remains a
+//! deliberate design decision documented at its handler in `event_handler`.
+//! This module makes the session record true; it does not add a new policy.
+
+use anyhow::Result;
+
+use crate::fs::locking::locked_read;
+use crate::fs::session_files::{find_session_file, save_session};
+use crate::models::session::{Session, SessionStatus};
+use crate::parser::frontmatter::parse_from_markdown;
+
+use super::persistence::Persistence;
+use super::Orchestrator;
+
+/// Whether an observed heartbeat may write to `session`.
+///
+/// Heartbeat files are keyed by STAGE, but session records accumulate: a stage
+/// that crashed and retried leaves every previous session on disk with its
+/// `stage_id` still set. So "this heartbeat names the stage this session names"
+/// is far weaker than "this session is the one currently running that stage",
+/// and only the strong form licenses a write. This is the same rule, for the
+/// same reason, as `is_stage_active_session` in `monitor/session_events.rs` and
+/// `stage_answerable_for_crash` in `core/crash_handler.rs`.
+///
+/// The session id is matched by the caller — it looks the record up by the id
+/// the heartbeat carries — so what is left to check here is that the record is
+/// still a live session for the stage the heartbeat is about.
+fn heartbeat_applies_to(session: &Session, stage_id: &str) -> bool {
+    if session.status != SessionStatus::Running {
+        return false;
+    }
+    session.stage_id.as_deref() == Some(stage_id)
+}
+
+impl Orchestrator {
+    /// Record a heartbeat against the session it names.
+    ///
+    /// Best-effort by design: a heartbeat is an observation, not a command, so
+    /// a missing or unparseable session file is logged and skipped rather than
+    /// failing the tick. `handle_events` isolates handler errors anyway, but a
+    /// heartbeat must not be the thing that produces them — one arrives after
+    /// every tool call in every live session.
+    pub(super) fn apply_heartbeat(
+        &self,
+        stage_id: &str,
+        session_id: &str,
+        context_percent: Option<f32>,
+    ) -> Result<()> {
+        let work_dir = self.persistence_work_dir();
+
+        let Some(path) = find_session_file(work_dir, session_id)? else {
+            tracing::debug!(
+                stage_id = %stage_id,
+                session_id = %session_id,
+                "Heartbeat names a session with no file on disk; ignoring"
+            );
+            return Ok(());
+        };
+
+        let mut session: Session = parse_from_markdown(&locked_read(&path)?, "Session")?;
+
+        if !heartbeat_applies_to(&session, stage_id) {
+            tracing::debug!(
+                stage_id = %stage_id,
+                session_id = %session_id,
+                status = ?session.status,
+                "Heartbeat does not apply: session is not the stage's live session"
+            );
+            return Ok(());
+        }
+
+        session.record_heartbeat(context_percent);
+        save_session(&session, work_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    fn running_session(stage_id: &str) -> Session {
+        let mut session = Session::new();
+        session.assign_to_stage(stage_id.to_string());
+        session.status = SessionStatus::Running;
+        session
+    }
+
+    #[test]
+    fn applies_to_the_stages_live_session() {
+        let session = running_session("build");
+        assert!(heartbeat_applies_to(&session, "build"));
+    }
+
+    #[test]
+    fn refuses_a_session_that_names_a_different_stage() {
+        let session = running_session("build");
+        assert!(!heartbeat_applies_to(&session, "test"));
+    }
+
+    #[test]
+    fn refuses_a_session_with_no_stage() {
+        let mut session = Session::new();
+        session.status = SessionStatus::Running;
+        assert!(!heartbeat_applies_to(&session, "build"));
+    }
+
+    /// A stage that crashed and retried leaves the old session on disk with
+    /// `stage_id` still set. A heartbeat from the live session must not revive
+    /// the corpse's `last_active`, or `loom sessions list` reports two running
+    /// sessions for one stage.
+    #[test]
+    fn refuses_a_terminal_session_for_the_same_stage() {
+        let mut session = running_session("build");
+        session.status = SessionStatus::Completed;
+        assert!(!heartbeat_applies_to(&session, "build"));
+    }
+
+    /// The regression this whole module exists for: before it, `last_active`
+    /// was written once at spawn and never again, so a session that had been
+    /// working for hours still reported its spawn timestamp.
+    ///
+    /// The spawn time is backdated rather than read from a second `Utc::now()`
+    /// — two adjacent `now()` calls can land in the same clock tick on macOS,
+    /// which makes a strict `>` against a just-spawned session flaky without
+    /// testing anything about the fix.
+    #[test]
+    fn heartbeat_advances_last_active_off_the_spawn_timestamp() {
+        let mut session = running_session("build");
+        let spawned_at = Utc::now() - Duration::hours(3);
+        session.last_active = spawned_at;
+
+        session.record_heartbeat(None);
+
+        assert!(
+            session.last_active > spawned_at,
+            "a heartbeat must move last_active off the spawn timestamp"
+        );
+    }
+
+    #[test]
+    fn a_percentage_reading_sets_context_tokens() {
+        let mut session = running_session("build");
+        session.context_limit = 200_000;
+        session.record_heartbeat(Some(65.0));
+        assert_eq!(session.context_tokens, 130_000);
+        assert!(session.is_context_exhausted());
+    }
+
+    /// The live hooks emit `context_percent: null`, so this is the common path.
+    /// It must still advance `last_active`, and it must not zero a reading a
+    /// previous heartbeat established.
+    #[test]
+    fn a_missing_percentage_preserves_the_previous_reading() {
+        let mut session = running_session("build");
+        session.context_limit = 200_000;
+        session.record_heartbeat(Some(65.0));
+        session.record_heartbeat(None);
+        assert_eq!(session.context_tokens, 130_000);
+    }
+
+    #[test]
+    fn an_out_of_range_percentage_is_ignored() {
+        let mut session = running_session("build");
+        session.context_limit = 200_000;
+        session.record_heartbeat(Some(50.0));
+        session.record_heartbeat(Some(-3.0));
+        session.record_heartbeat(Some(140.0));
+        session.record_heartbeat(Some(f32::NAN));
+        assert_eq!(session.context_tokens, 100_000);
+    }
+
+    #[test]
+    fn an_unknown_context_limit_leaves_tokens_alone() {
+        let mut session = running_session("build");
+        session.context_limit = 0;
+        session.record_heartbeat(Some(65.0));
+        assert_eq!(session.context_tokens, 0);
+    }
+}

--- a/loom/src/orchestrator/core/mod.rs
+++ b/loom/src/orchestrator/core/mod.rs
@@ -12,6 +12,7 @@ use std::io::{self, Write};
 mod completion_handler;
 mod crash_handler;
 mod event_handler;
+mod heartbeat_apply;
 mod merge_handler;
 mod orchestrator;
 mod persistence;

--- a/loom/src/orchestrator/monitor/detection.rs
+++ b/loom/src/orchestrator/monitor/detection.rs
@@ -17,6 +17,7 @@ use super::context::{context_health, context_usage_percent, ContextHealth};
 use super::events::MonitorEvent;
 use super::handlers::Handlers;
 use super::heartbeat::{HeartbeatStatus, HeartbeatWatcher};
+use super::parked::stage_looks_finished;
 
 /// Detection state for tracking changes
 pub struct Detection {
@@ -293,17 +294,14 @@ impl Detection {
                         if let Ok(Some(is_alive)) = handlers.check_session_alive(session) {
                             if is_alive {
                                 // Session is alive but not sending heartbeats - it's hung
-                                let last_activity = heartbeat_watcher
-                                    .get_heartbeat(stage_id)
-                                    .and_then(|hb| hb.activity.clone());
-
-                                events.push(MonitorEvent::SessionHung {
-                                    session_id: session.id.clone(),
-                                    stage_id: Some(stage_id.clone()),
+                                events.push(hung_event(
+                                    session,
+                                    stage_id,
+                                    stages,
+                                    heartbeat_watcher,
                                     stale_duration_secs,
                                     timeout_secs,
-                                    last_activity,
-                                });
+                                ));
 
                                 self.reported_hung_sessions.insert(session.id.clone());
                             }
@@ -329,5 +327,38 @@ impl Detection {
 impl Default for Detection {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Build the `SessionHung` event for a session whose heartbeat has gone stale.
+///
+/// Split out of [`Detection::detect_heartbeat_events`] so the classification
+/// has somewhere to live without growing that function, and so the two git
+/// probes behind [`stage_looks_finished`] are visibly paid once per hung
+/// report rather than once per poll.
+fn hung_event(
+    session: &Session,
+    stage_id: &str,
+    stages: &[Stage],
+    heartbeat_watcher: &HeartbeatWatcher,
+    stale_duration_secs: u64,
+    timeout_secs: u64,
+) -> MonitorEvent {
+    let last_activity = heartbeat_watcher
+        .get_heartbeat(stage_id)
+        .and_then(|hb| hb.activity.clone());
+
+    let finished_without_completing = stages
+        .iter()
+        .find(|s| s.id == stage_id)
+        .is_some_and(|stage| stage_looks_finished(session, stage));
+
+    MonitorEvent::SessionHung {
+        session_id: session.id.clone(),
+        stage_id: Some(stage_id.to_string()),
+        stale_duration_secs,
+        timeout_secs,
+        last_activity,
+        finished_without_completing,
     }
 }

--- a/loom/src/orchestrator/monitor/events.rs
+++ b/loom/src/orchestrator/monitor/events.rs
@@ -37,6 +37,11 @@ pub enum MonitorEvent {
         timeout_secs: u64,
         /// Last known activity from heartbeat
         last_activity: Option<String>,
+        /// The stage looks FINISHED rather than stuck: its branch carries
+        /// commits beyond its base and its worktree is clean, so the session
+        /// most likely ended its turn without running `loom stage complete`.
+        /// Advisory like the rest of this event — it only sharpens the warning.
+        finished_without_completing: bool,
     },
     SessionNeedsHandoff {
         session_id: String,

--- a/loom/src/orchestrator/monitor/mod.rs
+++ b/loom/src/orchestrator/monitor/mod.rs
@@ -18,6 +18,7 @@ pub mod events;
 pub mod failure_tracking;
 pub(crate) mod handlers;
 pub mod heartbeat;
+pub(crate) mod parked;
 mod session_events;
 
 #[cfg(test)]

--- a/loom/src/orchestrator/monitor/parked.rs
+++ b/loom/src/orchestrator/monitor/parked.rs
@@ -1,0 +1,197 @@
+//! Telling a PARKED stage apart from a HUNG one.
+//!
+//! Both look identical from the heartbeat alone — a live PID that has stopped
+//! writing `.work/heartbeat/<stage-id>.json` — but they need opposite
+//! responses from the operator:
+//!
+//! - **Hung**: the session is stuck partway through its work. Go look at it.
+//! - **Parked**: the session finished, committed, and ended its turn without
+//!   running `loom stage complete`. The work is done and gate-passing; the
+//!   stage just needs the transition, and every dependent stage is blocked
+//!   behind it until someone notices.
+//!
+//! Parking is not hypothetical and it is not rare. `hooks/commit-guard.sh` used
+//! to refuse a stop that left a stage in `Executing` (`exit 2`), but was
+//! downgraded to an advisory that returns 0, because Claude Code fires `Stop`
+//! hooks during Task/subagent waits and blocking there killed sessions
+//! mid-work. An advisory Stop hook's stderr is not fed back to the model, so
+//! the reminder now reaches nobody: the agent ends its turn and the stage sits
+//! in `Executing` indefinitely. Observed twice on one eight-stage plan
+//! (2026-08-24 and 2026-08-25), the second time parked overnight for 12h45m
+//! with every acceptance criterion already passing.
+//!
+//! This module does not change that policy — hung detection stays advisory,
+//! nothing here kills, retries, or transitions anything. It only lets the
+//! warning say which of the two situations the operator is looking at, and
+//! name the command that resolves the recoverable one.
+//!
+//! # What "finished" means here
+//!
+//! Two observable facts, both required:
+//!
+//! 1. the stage branch carries at least one commit beyond its base, and
+//! 2. the worktree has no uncommitted tracked changes.
+//!
+//! Untracked files are deliberately ignored: every loom worktree carries an
+//! untracked `.claude/` and a `.work` symlink, so a check that counted them
+//! would never fire. [`has_uncommitted_changes`] already excludes them.
+//!
+//! Every probe is best-effort and every failure answers "no". A wrong `false`
+//! costs the operator the sharper half of a warning they are getting anyway; a
+//! wrong `true` would tell them to complete a stage that is genuinely stuck
+//! partway through, which is how work gets lost.
+
+use std::path::Path;
+
+use crate::git::branch::{branch_name_for_stage, commits_ahead_of, has_uncommitted_changes};
+use crate::models::session::Session;
+use crate::models::stage::Stage;
+
+/// Whether `stage` looks finished-but-not-completed rather than stuck.
+///
+/// Called only for a session already flagged hung, so the cost of two git
+/// probes is paid once per hung report, not once per poll.
+pub(super) fn stage_looks_finished(session: &Session, stage: &Stage) -> bool {
+    let Some(worktree) = session.worktree_path.as_deref() else {
+        // Knowledge stages run in the main repository with no worktree. The
+        // branch/base reasoning below does not describe them, so decline.
+        return false;
+    };
+    let Some(base) = stage.base_branch.as_deref() else {
+        return false;
+    };
+    finished_in_worktree(worktree, &branch_name_for_stage(&stage.id), base)
+}
+
+/// The git half, split out so it can be tested against a real repository
+/// without constructing a `Session` and a `Stage`.
+fn finished_in_worktree(worktree: &Path, branch: &str, base: &str) -> bool {
+    let Ok(ahead) = commits_ahead_of(branch, base, worktree) else {
+        return false;
+    };
+    if ahead == 0 {
+        return false;
+    }
+    // A clean tree is the second half: commits alone would also describe a
+    // session that committed once and is still working on the rest.
+    matches!(has_uncommitted_changes(worktree), Ok(false))
+}
+
+/// Render the operator-facing warning for a hung session.
+///
+/// Lives here rather than inline at the handler so the parked/hung distinction
+/// is rendered where it is decided — and so it can be tested, which an inline
+/// `eprintln!` never could be.
+pub(crate) fn hung_warning(
+    session_id: &str,
+    stage_id: Option<&str>,
+    stale_duration_secs: u64,
+    timeout_secs: u64,
+    last_activity: Option<&str>,
+    finished_without_completing: bool,
+) -> String {
+    let stage_info = stage_id
+        .map(|s| format!(" (stage '{s}')"))
+        .unwrap_or_default();
+    let activity_info = last_activity
+        .map(|a| format!(", last: {a}"))
+        .unwrap_or_default();
+
+    let mut message = format!(
+        "Warning: Session '{session_id}'{stage_info} appears hung \
+(no heartbeat for {stale_duration_secs}s, budget {timeout_secs}s{activity_info})"
+    );
+
+    if finished_without_completing {
+        let id = stage_id.unwrap_or("<stage-id>");
+        message.push_str(&format!(
+            "\n  It looks FINISHED rather than stuck: commits on its branch and a clean \
+worktree. Run: loom stage complete {id}"
+        ));
+    }
+    message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::session::Session;
+    use crate::models::stage::Stage;
+    use std::path::PathBuf;
+
+    fn stage_with(base: Option<&str>) -> Stage {
+        let mut stage = Stage::new("Build".to_string(), None);
+        stage.id = "build".to_string();
+        stage.base_branch = base.map(str::to_string);
+        stage
+    }
+
+    fn session_with_worktree(path: Option<&str>) -> Session {
+        let mut session = Session::new();
+        if let Some(p) = path {
+            session.set_worktree_path(PathBuf::from(p));
+        }
+        session
+    }
+
+    /// A knowledge stage runs in the main repo and has no worktree; the
+    /// branch-and-base reasoning does not apply to it.
+    #[test]
+    fn a_session_without_a_worktree_is_never_called_finished() {
+        let session = session_with_worktree(None);
+        let stage = stage_with(Some("main"));
+        assert!(!stage_looks_finished(&session, &stage));
+    }
+
+    #[test]
+    fn a_stage_without_a_base_branch_is_never_called_finished() {
+        let session = session_with_worktree(Some("/nonexistent/worktree"));
+        let stage = stage_with(None);
+        assert!(!stage_looks_finished(&session, &stage));
+    }
+
+    /// The probes run against a path that is not a git repository at all, so
+    /// both fail. A failed probe must answer "no" rather than propagating or
+    /// defaulting to "finished" — telling an operator to complete a stage that
+    /// is actually stuck partway through is how work gets lost.
+    #[test]
+    fn a_failed_git_probe_answers_no() {
+        assert!(!finished_in_worktree(
+            Path::new("/nonexistent/worktree"),
+            "loom/build",
+            "main"
+        ));
+    }
+
+    #[test]
+    fn the_warning_names_the_completion_command_only_when_parked() {
+        let parked = hung_warning("s1", Some("build"), 900, 300, Some("Bash"), true);
+        assert!(parked.contains("loom stage complete build"));
+        assert!(parked.contains("no heartbeat for 900s"));
+        assert!(parked.contains("budget 300s"));
+        assert!(parked.contains("last: Bash"));
+
+        let stuck = hung_warning("s1", Some("build"), 900, 300, Some("Bash"), false);
+        assert!(!stuck.contains("loom stage complete"));
+        assert!(stuck.contains("appears hung"));
+    }
+
+    /// A hung session with no stage still renders; it must not print the word
+    /// "None" or an empty command an operator could paste.
+    #[test]
+    fn a_missing_stage_id_degrades_without_printing_none() {
+        let message = hung_warning("s1", None, 400, 300, None, true);
+        assert!(!message.contains("None"));
+        assert!(message.contains("<stage-id>"));
+    }
+
+    #[test]
+    fn an_unresolvable_branch_answers_no() {
+        let repo = std::env::temp_dir();
+        assert!(!finished_in_worktree(
+            &repo,
+            "loom/definitely-not-a-branch",
+            "definitely-not-a-base"
+        ));
+    }
+}


### PR DESCRIPTION
Two independent defects that together mean the daemon cannot tell what a live session is doing. Both were found while running an eight-stage plan; each commit stands alone and is separately revertable.

## 1. Heartbeats never reached the session record

`MonitorEvent::HeartbeatReceived` was handled by an empty block whose comment said the data was *"just used for internal tracking"*. Nothing tracked it — and `Session::update_context`, the only method that writes `context_tokens`, had **no non-test caller anywhere in the crate**.

So the pipeline worked right up to the last step and then dropped the data. Hooks rewrite `.work/heartbeat/<stage-id>.json` after every tool call, `HeartbeatWatcher` polls it, the monitor emits the event, and the session record learned nothing.

What reads the fields that never moved:

| Call site | Effect |
| --- | --- |
| `handoff/detector.rs` | usage always `0.0` → `is_context_exhausted` can never return true → **automatic handoff cannot fire**, `CONTEXT_CRITICAL_THRESHOLD` unreachable |
| `monitor/handlers.rs` | `BudgetExceeded` can never fire |
| `commands/status/data/collector.rs` | treats `context_tokens == 0` as "no reading" → context column blank for healthy and exhausted sessions alike |
| `orchestrator/signals/generate.rs` | every resumed agent told its context is 0% |
| anything deriving from `last_active` | measures from spawn — reads as "idle since it started" for a session working for hours |

Observed directly: all five session records on one plan carried `last_active` equal to their spawn timestamp and `context_tokens: 0`, while the heartbeat files were being rewritten correctly the whole time.

`Session::record_heartbeat` always advances `last_active`, and moves `context_tokens` only on a finite, in-range reading — a missing percentage **preserves** the previous value, since zeroing would silently retract a handoff already due. Applying it is guarded: the record must be `Running` and must currently own the stage the heartbeat names (heartbeat files are keyed by stage, and a retried stage leaves session corpses with `stage_id` still set — same rule as `is_stage_active_session` and `stage_answerable_for_crash`).

**Known gap, deliberately not papered over:** `context_percent` is `null` in practice — both `hooks/session-start.sh` and `hooks/post-tool-use.sh` emit a literal `null`, because Claude Code's PostToolUse payload does not carry context usage. The value is threaded through and tested so a hook gaining the field is a hook-only change. `last_active` becomes truthful immediately; `context_tokens` still awaits a source. I chose not to estimate it from transcript size — a wrong context number is worse than a missing one when it gates handoffs.

## 2. A parked stage was indistinguishable from a hung one

A stale heartbeat has two causes that look identical but need opposite responses: **hung** (stuck partway — go look) and **parked** (finished, committed, ended its turn without `loom stage complete` — the work is done and gate-passing, and every dependent stage is blocked behind a transition nobody made).

Parking is not rare. `hooks/commit-guard.sh` used to refuse a stop that left a stage `Executing` (`exit 2`) but is now advisory, because Stop hooks fire during Task/subagent waits and blocking there killed sessions mid-work. An advisory Stop hook's stderr is not fed back to the model, so the reminder now reaches nobody. Seen twice on one plan — the second time parked overnight for 12h45m with every acceptance criterion already passing.

`stage_looks_finished` classifies on two observable facts: the branch carries commits beyond its base, and the worktree has no uncommitted *tracked* changes. Untracked files are ignored deliberately — every worktree carries an untracked `.claude/` and a `.work` symlink, so counting them would mean the check never fires. Both probes are best-effort and **every failure answers "no"**: a wrong "no" costs the operator the sharper half of a warning they get anyway; a wrong "yes" would tell them to complete a stage that is genuinely stuck, which is how work gets lost.

The warning gains one line when it applies:

```
Warning: Session 's1' (stage 'wiring-eval') appears hung (no heartbeat for 45900s, budget 1200s, last: Bash)
  It looks FINISHED rather than stuck: commits on its branch and a clean worktree. Run: loom stage complete wiring-eval
```

Rendering moved into `monitor::parked` next to the classification, which makes the wording unit-testable — an inline `eprintln!` never was.

**Hung detection stays advisory.** Nothing here kills, retries, or transitions anything; only the wording changes.

**Not attempted:** restoring `commit-guard.sh`'s `exit 2`. The hook discards stdin, so it cannot distinguish a real session end from a subagent wait, and re-enabling the block without a behavioural test against current Claude Code risks reintroducing the worse failure it was downgraded to avoid. That seems like a call for a maintainer with a rig to test it on.

## Verification

- `cargo check`, `cargo build --no-default-features` — pass
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --test maintainability` — pass; **debt reduced, not grown**: `event_handler.rs` 468→467, `handle_one_event` 117→115, `detect_heartbeat_events` 99→96, all lowered here
- `cargo test` — 2718 passed, 15 new tests

Two tests fail on this branch: `context::tests::store::open_resolves_cache_at_main_project_root_from_linked_worktree` and `process::tests::unreaped_dead_child_is_not_alive`. **Both fail identically on unmodified `main`** — verified by stashing this work and re-running. They look environment-dependent (macOS) rather than related.

Both commits build and pass the gates independently.
